### PR TITLE
Fix API edit params

### DIFF
--- a/app/api/variants/route.ts
+++ b/app/api/variants/route.ts
@@ -110,7 +110,6 @@ export async function POST(req: NextRequest) {
       quality,
       background,
       user    : placeholderId,
-      response_format: 'b64_json',
     });
 
     /* 7 ▸ Validate response */


### PR DESCRIPTION
## Summary
- drop `response_format` from openai.images.edit call

## Testing
- `npm run lint` *(fails: next not found)*