### PR TITLE
Implement image cropping

### DIFF
--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useState } from 'react'
 import { fabric }              from 'fabric'
 import { getActiveTextbox }    from './FabricCanvas'
+import { useEditor }           from './EditorStore'
 
 type Mode = 'staff'|'customer'
 const fonts = ['Arial','Georgia','monospace','Dingos Stamp']
@@ -25,6 +26,9 @@ interface Props{
 export default function TextToolbar(props:Props){
   const {canvas:fc,addText,addImage,onUndo,onRedo,onSave,mode,saving}=props
   if(!fc) return null
+
+  const startCrop = useEditor(s=>s.startCrop)
+  const activePage = useEditor(s=>s.activePage)
 
   /* re-render when Fabric selection changes */
   const [_,force] = useState({})
@@ -76,6 +80,17 @@ export default function TextToolbar(props:Props){
                      e.currentTarget.value=''
                    }}/>
           </label>
+
+          {/* Crop */}
+          <button
+            disabled={(fc.getActiveObject() as any)?.type !== 'image'}
+            onClick={() => {
+              const obj = fc.getActiveObject() as any
+              if (obj && obj.type === 'image')
+                startCrop(activePage, obj.layerIdx)
+            }}
+            className="toolbar-btn"
+          >Crop</button>
 
           {/* font family */}
           <select disabled={!tb} value={tb?.fontFamily ?? fonts[0]}

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -64,6 +64,7 @@ if (raw._type === 'aiLayer') {
       scaleX: raw.scaleX,
       scaleY: raw.scaleY,
       opacity: raw.opacity,
+      ...(raw.crop && { crop: raw.crop }),
       selectable: raw._type !== 'bgImage',
       editable  : raw._type !== 'bgImage',
     }
@@ -148,6 +149,7 @@ if (layer.type === 'image') {
     ...(layer.opacity != null && { opacity: layer.opacity }),
     ...(layer.scaleX  != null && { scaleX: layer.scaleX }),
     ...(layer.scaleY  != null && { scaleY: layer.scaleY }),
+    ...(layer.crop && { crop: layer.crop }),
   };
 
 /* 1️⃣ Already have assetId → easiest */

--- a/sanity/schemaTypes/editableImage.ts
+++ b/sanity/schemaTypes/editableImage.ts
@@ -26,6 +26,20 @@ export default defineType({
 
     /* raw URL / blob while the upload is still in progress */
     defineField({name: 'srcUrl', type: 'url', hidden: true}),
+
+    /* optional crop rectangle */
+    defineField({
+      name : 'crop',
+      type : 'object',
+      title: 'Crop',
+      hidden: true,
+      fields: [
+        { name: 'left',   type: 'number' },
+        { name: 'top',    type: 'number' },
+        { name: 'width',  type: 'number' },
+        { name: 'height', type: 'number' },
+      ],
+    }),
   ],
 
   /* ── layer-list preview ── */


### PR DESCRIPTION
## Summary
- add hidden crop data to the editable image schema
- round‑trip crop info through layerAdapters
- support crop fields in the editor store
- implement crop mode in FabricCanvas with commit/cancel actions
- expose crop controls via TextToolbar

## Testing
- `npm run lint` *(fails: `next` not found)*