### PR TITLE
Fix crop state handling

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -98,6 +98,12 @@ export default function CardEditor({
     setCanvasMap(list => { const next = [...list]; next[idx] = fc; return next })
   const activeFc = canvasMap[activeIdx]
 
+  /* track cropping state per page */
+  const [cropping, setCropping] =
+    useState<[boolean, boolean, boolean, boolean]>([false, false, false, false])
+  const handleCroppingChange = (idx: number, state: boolean) =>
+    setCropping(prev => { const next = [...prev] as typeof prev; next[idx] = state; return next })
+
   /* 5 ─ save ------------------------------------------------------ */
   const [saving, setSaving] = useState(false)
   const handleSave = async () => {
@@ -233,20 +239,44 @@ const handleSwap = (url: string) => {
         <div className="flex-1 flex justify-center items-start overflow-auto bg-gray-100 dark:bg-gray-900 pt-6 gap-6">
           {/* front */}
           <div className={section === 'front' ? box : 'hidden'}>
-            <FabricCanvas pageIdx={0} page={pages[0]} onReady={fc => onReady(0, fc)} />
+            <FabricCanvas
+              pageIdx={0}
+              page={pages[0]}
+              onReady={fc => onReady(0, fc)}
+              isCropping={cropping[0]}
+              onCroppingChange={state => handleCroppingChange(0, state)}
+            />
           </div>
           {/* inside */}
           <div className={section === 'inside' ? 'flex gap-6' : 'hidden'}>
             <div className={box}>
-              <FabricCanvas pageIdx={1} page={pages[1]} onReady={fc => onReady(1, fc)} />
+              <FabricCanvas
+                pageIdx={1}
+                page={pages[1]}
+                onReady={fc => onReady(1, fc)}
+                isCropping={cropping[1]}
+                onCroppingChange={state => handleCroppingChange(1, state)}
+              />
             </div>
             <div className={box}>
-              <FabricCanvas pageIdx={2} page={pages[2]} onReady={fc => onReady(2, fc)} />
+              <FabricCanvas
+                pageIdx={2}
+                page={pages[2]}
+                onReady={fc => onReady(2, fc)}
+                isCropping={cropping[2]}
+                onCroppingChange={state => handleCroppingChange(2, state)}
+              />
             </div>
           </div>
           {/* back */}
           <div className={section === 'back' ? box : 'hidden'}>
-            <FabricCanvas pageIdx={3} page={pages[3]} onReady={fc => onReady(3, fc)} />
+            <FabricCanvas
+              pageIdx={3}
+              page={pages[3]}
+              onReady={fc => onReady(3, fc)}
+              isCropping={cropping[3]}
+              onCroppingChange={state => handleCroppingChange(3, state)}
+            />
           </div>
         </div>
 

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -281,9 +281,10 @@ interface Props {
   page?      : TemplatePage
   onReady    : (fc: fabric.Canvas | null) => void
   isCropping?: boolean
+  onCroppingChange?: (state: boolean) => void
 }
 
-export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = false }: Props) {
+export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = false, onCroppingChange }: Props) {
   const canvasRef    = useRef<HTMLCanvasElement>(null)
   const fcRef        = useRef<fabric.Canvas | null>(null)
   const hoverRef     = useRef<fabric.Rect | null>(null)
@@ -336,6 +337,7 @@ const patchCropFn = (name: 'commitCrop' | 'cancelCrop') => {
     anyFc[name] = (...args: any[]) => {
       cropMask.visible = false
       fc.requestRenderAll()
+      onCroppingChange?.(false)
       return orig(...args)
     }
   }
@@ -356,6 +358,7 @@ const dash = (gap:number) => [gap / SCALE, (gap - 2) / SCALE]
 const startCrop = (img: fabric.Image) => {
   if (croppingRef.current) return
   croppingRef.current = true
+  onCroppingChange?.(true)
   cropImgRef.current = img
   cropStartRef.current = {
     left  : img.left  ?? 0,
@@ -446,6 +449,7 @@ const cancelCrop = () => {
   cropImgRef.current = null
   cropStartRef.current = null
   croppingRef.current = false
+  onCroppingChange?.(false)
   if (img) fc.setActiveObject(img)
   fc.requestRenderAll()
 }
@@ -482,8 +486,7 @@ const commitCrop = () => {
       cropH: img.height,
     })
   }
-
-  startCrop(img)
+  onCroppingChange?.(false)
 }
 
 /* ── 2 ▸ Hover overlay only ─────────────────────────────── */


### PR DESCRIPTION
## Summary
- remove re-start of crop mode in `commitCrop`
- synchronize crop overlay with start/cancel/commit actions
- expose cropping state callbacks and wire it up in `CardEditor`

## Testing
- `npm run lint` *(fails: `next` not found)*