### PR TITLE
Fix crop window movement

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -399,6 +399,7 @@ const startCrop = (img: fabric.Image) => {
   cropGroupRef.current = grp
   fc.add(grp)
   fc.setActiveObject(grp)
+  fc.requestRenderAll()
 
   const sync = () => {
     const g  = cropGroupRef.current


### PR DESCRIPTION
## Summary
- keep crop group anchored while repositioning image
- prevent crop window from drifting while dragging

## Testing
- `npm run lint` *(fails: react-hooks rule violations)*