### PR TITLE
Improve image crop mode UX

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -214,9 +214,28 @@ const handleSwap = (url: string) => {
      onUndo   ={undo}
      onRedo   ={redo}
      onSave   ={handleSave}
-     mode     ={mode}
-     saving   ={saving}
+      mode     ={mode}
+      saving   ={saving}
 />
+
+        {cropping[activeIdx] && (
+          <div className="absolute top-2 inset-x-0 flex justify-center z-30 pointer-events-none">
+            <div className="flex gap-2 pointer-events-auto">
+              <button
+                onClick={() => canvasMap[activeIdx]?.commitCrop?.()}
+                className="px-3 py-1 rounded bg-green-600 text-white"
+              >
+                ✔ Done
+              </button>
+              <button
+                onClick={() => canvasMap[activeIdx]?.cancelCrop?.()}
+                className="px-3 py-1 rounded bg-gray-300"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
 
         {/* tabs */}
         <nav className="flex justify-center gap-8 py-3 text-sm font-medium">


### PR DESCRIPTION
## Summary
- add crop toolbar with Done/Cancel buttons
- expose `commitCrop` and `cancelCrop` on Fabric canvas
- tweak crop group styling and enable rotation
- support shift-drag to keep aspect ratio

## Testing
- `npm run lint` *(fails: React hook rule violations)*