### PR TITLE
Add sticky Walty navbar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,10 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --walty-cream : #F7F3EC;
+  --walty-teal  : #005B55;
+  --walty-orange: #C64A19;
+  --walty-brown : #3E2C20;
 }
 
 /* ❷  Font tokens */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,16 @@
 import React from "react";
 import "./globals.css";
 import { Domine, Inter } from "next/font/google";
+import WaltyNav from "@/components/site/WaltyNav";
 
-const inter = Inter({
+export const domine = Domine({
+  weight: ["400", "700"],
+  subsets: ["latin"],
+  variable: "--font-domine",
+});
+export const inter = Inter({
   subsets: ["latin"],
   variable: "--font-inter",
-  display: "swap",
-});
-const domine = Domine({
-  subsets: ["latin"],
-  weight: ["400", "700"],
-  variable: "--font-domine",
-  display: "swap",
 });
 
 export const metadata = {
@@ -25,7 +24,8 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${inter.variable} ${domine.variable} font-sans`}>
+      <body className={`${inter.variable} ${domine.variable}`}>
+        <WaltyNav />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,26 +14,7 @@ export default function HomePage() {
       className="min-h-screen font-sans"
       style={{ backgroundColor: cream, color: teal }}
     >
-      {/* NAVBAR */}
-      <nav className="border-b" style={{ borderColor: `${teal}30` }}>
-        <div className="mx-auto max-w-7xl flex items-center justify-between px-6 py-4">
-          <Link href="/" className="shrink-0">
-            <Image
-              src="/images/logo-pill-teal.svg"
-              alt="Walty logo"
-              width={110}
-              height={38}
-            />
-          </Link>
-          <Link
-            href="/templates"
-            className="rounded-md px-4 py-2 text-sm font-semibold shadow"
-            style={{ backgroundColor: orange, color: cream }}
-          >
-            Design a Card
-          </Link>
-        </div>
-      </nav>
+
 
       {/* HERO */}
       <section className="mx-auto max-w-7xl grid md:grid-cols-2 gap-12 px-6 py-24 items-center">

--- a/components/site/WaltyNav.tsx
+++ b/components/site/WaltyNav.tsx
@@ -1,0 +1,68 @@
+"use client";
+import Image from "next/image";
+import Link from "next/link";
+import { Search, Bell, User, ShoppingBag } from "lucide-react";
+import { useEffect } from "react";
+
+export default function WaltyNav() {
+  useEffect(() => {
+    const nav = document.getElementById("waltyNav");
+    const t = () => nav && nav.classList.toggle("shadow-md", window.scrollY > 8);
+    t();
+    window.addEventListener("scroll", t, { passive: true });
+    return () => window.removeEventListener("scroll", t);
+  }, []);
+
+  return (
+    <header
+      id="waltyNav"
+      className="sticky top-0 z-50 transition-shadow duration-200 bg-[--walty-cream]"
+    >
+      {/* TOP ROW */}
+      <div className="mx-auto max-w-7xl flex items-center gap-6 px-4 py-3">
+        <Link href="/">
+          <Image
+            src="/images/logo-pill-teal.svg"
+            alt="Walty"
+            width={112}
+            height={38}
+          />
+        </Link>
+        <div className="relative flex-1 max-w-xl hidden md:block">
+          <input
+            className="w-full h-10 rounded-full pl-12 pr-4 bg-white/70 border-[2px] border-[--walty-teal] placeholder:text-slate-500 font-sans text-[16px]/[24px] outline-none"
+            placeholder="Search birthday cards…"
+          />
+          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 stroke-[--walty-teal]" />
+        </div>
+        <nav className="flex items-center gap-6 ml-auto text-xs font-sans">
+          <Link href="/reminders" className="hidden sm:flex flex-col items-center">
+            <Bell className="w-6 h-6 stroke-[--walty-teal] hover:stroke-[--walty-orange]" />
+            Reminders
+          </Link>
+          <Link href="/account" className="hidden sm:flex flex-col items-center">
+            <User className="w-6 h-6 stroke-[--walty-teal] hover:stroke-[--walty-orange]" />
+            Account
+          </Link>
+          <Link href="/basket" className="flex flex-col items-center">
+            <ShoppingBag className="w-6 h-6 stroke-[--walty-teal] hover:stroke-[--walty-orange]" />
+            Basket
+          </Link>
+        </nav>
+      </div>
+
+      {/* BIRTHDAY FILTER RAIL */}
+      <nav className="border-t border-[rgba(0,91,85,.2)] overflow-x-auto whitespace-nowrap">
+        <ul className="mx-auto max-w-7xl flex gap-8 px-4 py-3 font-serif text-[17px] font-bold">
+          {["Recipient", "Age", "Style", "Interests"].map((l) => (
+            <li key={l}>
+              <button className="flex items-center gap-1 hover:text-[--walty-orange]">
+                {l} ▾
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add color tokens for Walty brand palette
- create `<WaltyNav>` client component with sticky shadow effect
- include `<WaltyNav>` in the app layout
- remove old navbar markup from the home page

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm run build` *(fails: EHOSTUNREACH while fetching Google Fonts)*