### PR TITLE
Fix toolbar icon button sizing

### DIFF
--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -8,11 +8,12 @@
 
 "use client";
 
-import { useEffect, useState, forwardRef } from "react";
+import { useEffect, useState } from "react";
 import { fabric } from "fabric";
 import { useEditor } from "./EditorStore";
 import ToolFlipImage     from "./toolbar/ToolFlipImage";
 import ToolOpacitySlider from "./toolbar/ToolOpacitySlider";
+import IconButton        from "./toolbar/IconButton";
 
 /* lucide-react icons */
 import {
@@ -33,54 +34,7 @@ import {
   AlignToPageHorizontal,
 } from "./toolbar/AlignToPage";
 
-/* ───────────────────────── Icon button ─── */
-interface IconBtnProps {
-  Icon: React.ElementType;
-  label: string;          // tooltip
-  caption?: string;       // text under icon
-  onClick: () => void;
-  active?: boolean;
-  disabled?: boolean;
-}
 
-const IconButton = forwardRef<HTMLButtonElement, IconBtnProps>(
-  (
-    {
-      Icon,
-      label,
-      caption = label.split(" ")[0],
-      onClick,
-      active,
-      disabled,
-    },
-    ref
-  ) => (
-    <button
-      ref={ref}
-      type="button"
-      aria-label={label}
-      title={label}
-      onClick={onClick}
-      disabled={disabled}
-      className={`flex flex-col items-center justify-center w-12 p-2 gap-0.5
-                  rounded focus:outline-none focus:ring-2 focus:ring-[--walty-orange] focus:ring-offset-1
-                  hover:bg-[--walty-orange]/10 disabled:opacity-40
-                  ${active ? "bg-[--walty-orange]/10" : ""}`}
-    >
-      <Icon
-        className={`w-6 h-6 stroke-[--walty-teal] transition-colors
-                    ${active ? "stroke-[--walty-orange]" : "hover:stroke-[--walty-orange]"}`}
-      />
-      <span
-        className={`text-[11px] leading-none font-medium tracking-wide
-                    ${active ? "text-[--walty-orange]" : "text-[--walty-teal]"}`}
-      >
-        {caption}
-      </span>
-    </button>
-  )
-);
-IconButton.displayName = "IconButton";
 
 /* ───────────────────────── main toolbar component ─── */
 interface Props {

--- a/app/components/toolbar/IconButton.tsx
+++ b/app/components/toolbar/IconButton.tsx
@@ -12,7 +12,9 @@ interface IconBtnProps {
 }
 
 /**
- * 44-px hit-area   ▪︎   icon + 10-px caption
+ * Toolbar icon button — 48 px square hit-area with 24 px icon
+ * and 11 px caption text. Forward-refs the underlying button so
+ * popovers can anchor to it.
  */
 const IconButton = forwardRef<HTMLButtonElement, IconBtnProps>(
   (
@@ -26,7 +28,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconBtnProps>(
       title={label}
       onClick={onClick}
       disabled={disabled}
-      className={`flex flex-col items-center justify-center gap-0.5 w-12 p-2
+      className={`flex flex-col items-center justify-center w-12 p-2 gap-0.5
                   rounded focus:outline-none
                   focus:ring-2 focus:ring-[--walty-orange] focus:ring-offset-1
                   hover:bg-[--walty-orange]/10 disabled:opacity-40
@@ -34,13 +36,13 @@ const IconButton = forwardRef<HTMLButtonElement, IconBtnProps>(
     >
       {/* icon */}
       <Icon
-        className={`w-5 h-5 stroke-[--walty-teal] transition-colors
+        className={`w-6 h-6 stroke-[--walty-teal] transition-colors
                     ${active ? "stroke-[--walty-orange]"
                               : "hover:stroke-[--walty-orange]"}`}
       />
       {/* caption */}
       <span
-        className={`text-[10px] leading-none font-medium
+        className={`text-[11px] leading-none font-medium tracking-wide
                     ${active ? "text-[--walty-orange]"
                               : "text-[--walty-teal]"}`}
       >
@@ -49,5 +51,6 @@ const IconButton = forwardRef<HTMLButtonElement, IconBtnProps>(
     </button>
   )
 );
+IconButton.displayName = "IconButton";
 
 export default IconButton;


### PR DESCRIPTION
## Summary
- size toolbar `IconButton` at 24px and 11px text
- import shared `IconButton` in `ImageToolbar`

## Testing
- `npm run lint` *(fails: React hooks and display name issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6839e15d74688323afb37c48c175f7d3