### PR TITLE
Add global EditorCommands toolbar

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -17,6 +17,7 @@ import LayerPanel                       from './LayerPanel'
 import FabricCanvas                      from './FabricCanvas'
 import TextToolbar                      from './TextToolbar'
 import ImageToolbar                     from './ImageToolbar'
+import EditorCommands                   from './EditorCommands'
 import SelfieDrawer                     from './SelfieDrawer'
 import type { TemplatePage }            from './FabricCanvas'
 
@@ -228,14 +229,12 @@ const handleSwap = (url: string) => {
 
       {/* main */}
      <div className="flex-1 flex flex-col">
+       <EditorCommands onUndo={undo} onRedo={redo} onSave={handleSave} saving={saving} />
      {activeType === 'text' && (
        <TextToolbar
          canvas={activeFc}
          addText={addText}
          addImage={addImage}
-         onUndo={undo}
-         onRedo={redo}
-         onSave={handleSave}
          mode={mode}
          saving={saving}
        />
@@ -243,9 +242,6 @@ const handleSwap = (url: string) => {
      {activeType === 'image' && (
        <ImageToolbar
          canvas={activeFc}
-         onUndo={undo}
-         onRedo={redo}
-         onSave={handleSave}
          saving={saving}
        />
      )}

--- a/app/components/EditorCommands.tsx
+++ b/app/components/EditorCommands.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React from 'react';
+
+interface Props {
+  onUndo: () => void;
+  onRedo: () => void;
+  onSave: () => void | Promise<void>;
+  saving: boolean;
+}
+
+export default function EditorCommands({ onUndo, onRedo, onSave, saving }: Props) {
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!document.getElementById('command-btn-css')) {
+      const shared = 'border px-2 py-[2px] rounded hover:bg-gray-100 disabled:opacity-40';
+      const style = document.createElement('style');
+      style.id = 'command-btn-css';
+      style.innerHTML = `.command-btn{${shared}}`;
+      document.head.appendChild(style);
+    }
+  }, []);
+
+  return (
+    <div className="fixed right-4 top-2 z-40 flex gap-4 pointer-events-auto select-none">
+      <button onClick={onUndo} className="command-btn">↶ Undo</button>
+      <button onClick={onRedo} className="command-btn">↷ Redo</button>
+      <button
+        onClick={onSave}
+        disabled={saving}
+        className={`command-btn font-semibold ${saving ? 'opacity-50 cursor-not-allowed' : 'text-blue-600'}`}
+      >
+        {saving ? '⏳ Saving…' : '💾 Save'}
+      </button>
+    </div>
+  );
+}

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -1,7 +1,7 @@
 /**
- * Walty‑branded image toolbar · single‑row layout (undo / redo / save float right)
+ * Walty‑branded image toolbar · single‑row layout
  * ————————————————————————————————————————
- * • Toolbar itself stays centred; Undo‑Redo‑Save live in a separate cluster at top‑right.
+ * • Toolbar itself stays centred.
  * • 48 × 48 px buttons, 24 px icons, 11 px captions.
  * • Uniform 24 px gap (`gap-6`) between buttons inside the bar.
  */
@@ -39,13 +39,10 @@ import {
 /* ───────────────────────── main toolbar component ─── */
 interface Props {
   canvas: fabric.Canvas | null;
-  onUndo: () => void;
-  onRedo: () => void;
-  onSave: () => void | Promise<void>;
   saving: boolean;
 }
 
-export default function ImageToolbar({ canvas: fc, onUndo, onRedo, onSave, saving }: Props) {
+export default function ImageToolbar({ canvas: fc, saving }: Props) {
   /* local state / editor wiring */
   const [, force]      = useState({});
   const reorder        = useEditor(s => s.reorder);
@@ -156,22 +153,6 @@ export default function ImageToolbar({ canvas: fc, onUndo, onRedo, onSave, savin
         <IconButton Icon={Trash2} label="Delete image" caption="Delete" onClick={deleteCurrent} />
       </div>
 
-      {/* undo / redo / save cluster */}
-      <div className="absolute right-4 top-2 flex gap-3 pointer-events-auto">
-        <IconButton Icon={RotateCcw} label="Undo" onClick={onUndo} />
-        <IconButton Icon={RotateCw} label="Redo" onClick={onRedo} />
-        <button
-          type="button"
-          onClick={onSave}
-          disabled={saving}
-          className={`flex items-center gap-1 px-3 py-2 rounded font-semibold
-                      ${saving ? "opacity-50 cursor-not-allowed"
-                                : "text-[--walty-orange] hover:bg-[--walty-orange]/10"}`}
-        >
-          <Save className="w-5 h-5" />
-          {saving ? "Saving…" : "Save"}
-        </button>
-      </div>
     </div>
   );
 }

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -1,5 +1,5 @@
 /**********************************************************************
- * TextToolbar.tsx – rich-text controls + Undo · Redo · Save          *
+ * TextToolbar.tsx – rich-text controls                               *
  * keeps focus after every style change (no flicker)                  *
  *********************************************************************/
 'use client'
@@ -15,15 +15,12 @@ interface Props{
   canvas   : fabric.Canvas|null
   addText  : () => void
   addImage : (file:File)=>void
-  onUndo   : () => void
-  onRedo   : () => void
-  onSave   : () => void|Promise<void>
   mode     : Mode
   saving   : boolean
 }
 
 export default function TextToolbar(props:Props){
-  const {canvas:fc,addText,addImage,onUndo,onRedo,onSave,mode,saving}=props
+  const {canvas:fc,addText,addImage,mode,saving}=props
 
   /* re-render when Fabric selection changes */
   const [_,force] = useState({})
@@ -156,15 +153,6 @@ export default function TextToolbar(props:Props){
         </div>
       )}
 
-      {/* ───────── ② COMMANDS ───────── */}
-      <div className="absolute right-4 top-2 flex gap-4 pointer-events-auto">
-        <button onClick={onUndo} className="command-btn">↶ Undo</button>
-        <button onClick={onRedo} className="command-btn">↷ Redo</button>
-        <button onClick={onSave} disabled={saving}
-                className={`command-btn font-semibold ${saving?'opacity-50 cursor-not-allowed':'text-blue-600'}`}>
-          {saving ? '⏳ Saving…' : '💾 Save'}
-        </button>
-      </div>
     </div>
   )
 }
@@ -173,6 +161,6 @@ export default function TextToolbar(props:Props){
 if(typeof window!=='undefined' && !document.getElementById('toolbar-css')){
   const shared='border px-2 py-[2px] rounded hover:bg-gray-100 disabled:opacity-40'
   const style=document.createElement('style'); style.id='toolbar-css'
-  style.innerHTML=`.toolbar-btn{${shared}} .command-btn{${shared}}`
+  style.innerHTML=`.toolbar-btn{${shared}}`
   document.head.appendChild(style)
 }


### PR DESCRIPTION
## Summary
- introduce `EditorCommands` fixed-position toolbar with Undo/Redo/Save
- display the new toolbar in `CardEditor`
- remove command buttons from `TextToolbar` and `ImageToolbar`
- keep `.command-btn` styles by injecting from `EditorCommands`

## Testing
- `npm run lint` *(fails: React Hook rule errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_683b3e8ff1d883238398f272800eef6d