### PR TITLE
Revamp text toolbar

### DIFF
--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -1,139 +1,248 @@
 /**********************************************************************
  * TextToolbar.tsx – rich-text controls                               *
- * keeps focus after every style change (no flicker)                  *
+ * – Single-row Walty pill (matches Image toolbar)                    *
+ * – Captions kept on every icon except font & size controls          *
  *********************************************************************/
 'use client'
 
 import { useEffect, useState } from 'react'
 import { fabric }              from 'fabric'
 import { getActiveTextbox }    from './FabricCanvas'
+import { useEditor }           from './EditorStore'
+
+/* UI building blocks */
 import IconButton              from './toolbar/IconButton'
+import { FontFamilySelect }    from './toolbar/FontFamilySelect'
+import { FontSizeStepper }     from './toolbar/FontSizeStepper'
 import ToolTextOpacitySlider   from './toolbar/ToolTextOpacitySlider'
+
+/* lucide-react icons */
 import {
-  Type,
-  Bold,
-  Italic,
-  Underline,
-  CaseUpper,
-  CaseLower,
-  CaseSensitive,
-  AlignLeft,
-  AlignCenter,
-  AlignRight,
-  AlignJustify,
+  Bold, Italic, Underline,
+  CaseUpper, CaseLower, CaseSensitive,
+  AlignLeft, AlignCenter, AlignRight, AlignJustify,
+  Lock, Unlock, ArrowDownToLine, ArrowUpToLine,
 } from 'lucide-react'
 
-type Mode = 'staff'|'customer'
-const fonts = ['Arial','Georgia','monospace','Dingos Stamp']
+/* helper icons already used in Image toolbar */
+import {
+  AlignToPageVertical,
+  AlignToPageHorizontal,
+} from './toolbar/AlignToPage'
 
-interface Props{
-  canvas   : fabric.Canvas|null
-  addText  : () => void
-  addImage : (file:File)=>void
+type Mode = 'staff' | 'customer'
+const fonts = ['Arial', 'Georgia', 'monospace', 'Dingos Stamp']
+
+interface Props {
+  canvas   : fabric.Canvas | null
+  addText  : () => void          // kept in props, just not shown in UI
+  addImage : (file: File) => void
   mode     : Mode
   saving   : boolean
 }
 
-export default function TextToolbar(props:Props){
-  const {canvas:fc,addText,addImage,mode,saving}=props
+export default function TextToolbar (props: Props) {
+  const { canvas: fc, mode } = props
 
-  /* re-render when Fabric selection changes */
-  const [_,force] = useState({})
-  useEffect(()=>{
-    if(!fc) return
-    const tick=()=>force({})
-    fc.on('selection:created',tick)
-      .on('selection:updated',tick)
-      .on('selection:cleared',tick)
-    return()=>{fc.off('selection:created',tick)
-                .off('selection:updated',tick)
-                .off('selection:cleared',tick)}
-  },[fc])
+  /* ------------------------------------------------------------------ */
+  /* 1.  Re-render whenever Fabric selection changes                    */
+  /* ------------------------------------------------------------------ */
+  const [_, force] = useState({})
+  useEffect(() => {
+    if (!fc) return
+    const tick = () => force({})
+    fc.on('selection:created', tick)
+      .on('selection:updated', tick)
+      .on('selection:cleared', tick)
+    return () => {
+      fc.off('selection:created', tick)
+        .off('selection:updated', tick)
+        .off('selection:cleared', tick)
+    }
+  }, [fc])
 
-  const tb = fc ? getActiveTextbox(fc) : null
+  if (!fc) return null
+  const tb = getActiveTextbox(fc)
+
+  /* ------------------------------------------------------------------ */
+  /* 2.  Store access for layer order & locking                         */
+  /* ------------------------------------------------------------------ */
+  const reorder     = useEditor(s => s.reorder)
+  const updateLayer = useEditor(s => s.updateLayer)
+  const activePage  = useEditor(s => s.activePage)
+  const layerCount  = useEditor(
+    s => s.pages[s.activePage]?.layers.length || 0,
+  )
+
+  /* ------------------------------------------------------------------ */
+  /* 3.  Case-cycle & align-cycle helpers                               */
+  /* ------------------------------------------------------------------ */
   const [caseState, setCaseState] =
     useState<'upper' | 'title' | 'lower'>('upper')
+
   const alignOrder = ['left', 'center', 'right', 'justify'] as const
-  const alignSymbols: Record<string, string> = {
-    left: '←',
-    center: '↔︎',
-    right: '→',
-    justify: '⎯',
-  }
   const cycleAlign = () => {
     if (!tb) return
     const current = (tb.textAlign ?? 'left') as typeof alignOrder[number]
-    const idx = alignOrder.indexOf(current)
-    const next = alignOrder[(idx + 1) % alignOrder.length]
+    const idx     = alignOrder.indexOf(current)
+    const next    = alignOrder[(idx + 1) % alignOrder.length]
     mutate({ textAlign: next as any })
   }
-  if(!fc) return null
 
-  /** mutate helper – apply Fabric props, keep focus, fire modified */
-  const mutate = (p:Partial<fabric.Textbox>)=>{
-    if(!tb) return
+  /* ------------------------------------------------------------------ */
+  /* 4.  Centre-on-page maths (copied from Image toolbar)               */
+  /* ------------------------------------------------------------------ */
+  const zoom = fc.viewportTransform?.[0] ?? 1
+  const fcH  = (fc.getHeight() ?? 0) / zoom
+  const fcW  = (fc.getWidth()  ?? 0) / zoom
+
+  const cycleVertical = () => {
+    if (!tb) return
+    const { top, height } = tb.getBoundingRect(true, true)
+    const pos = [0, fcH / 2 - height / 2, fcH - height]
+    mutate({ top: pos[(pos.findIndex(p => Math.abs(top - p) < 1) + 1) % 3] })
+  }
+
+  const cycleHorizontal = () => {
+    if (!tb) return
+    const { left, width } = tb.getBoundingRect(true, true)
+    const pos = [0, fcW / 2 - width / 2, fcW - width]
+    mutate({ left: pos[(pos.findIndex(p => Math.abs(left - p) < 1) + 1) % 3] })
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* 5.  Lock / unlock & layer-order helpers                            */
+  /* ------------------------------------------------------------------ */
+  const locked = Boolean((tb as any)?.locked)
+  const toggleLock = () => {
+    if (!tb) return
+    const next = !locked
+    ;(tb as any).locked = next
+    tb.set({
+      lockMovementX: next,
+      lockMovementY: next,
+      lockScalingX : next,
+      lockScalingY : next,
+      lockRotation : next,
+    })
+    fc.requestRenderAll()
+    updateLayer(activePage, (tb as any).layerIdx, { locked: next })
+  }
+
+  const sendBackward = () => {
+    const idx = (tb as any).layerIdx ?? 0
+    if (idx < layerCount - 1) reorder(idx, idx + 1)
+  }
+  const bringForward = () => {
+    const idx = (tb as any).layerIdx ?? 0
+    if (idx > 0 && idx <= layerCount - 1) reorder(idx, idx - 1)
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* 6.  mutate helper – keeps focus & fires Fabric events              */
+  /* ------------------------------------------------------------------ */
+  const mutate = (p: Partial<fabric.Textbox>) => {
+    if (!tb) return
     tb.set(p); tb.setCoords()
     fc.setActiveObject(tb); fc.requestRenderAll()
-    tb.fire('modified'); fc.fire('object:modified',{target:tb})
+    tb.fire('modified'); fc.fire('object:modified', { target: tb })
     force({})
   }
 
-  /* ---------------------------------------------------------------- */
+  /* ------------------------------------------------------------------ */
+  /* 7.  Render                                                         */
+  /* ------------------------------------------------------------------ */
   return (
     <div className="fixed inset-x-0 top-2 z-30 flex justify-center pointer-events-none select-none">
 
-      {/* ───────── ① MAIN TOOLBAR (staff only) ───────── */}
-      {mode==='staff' && (
+      {mode === 'staff' && (
         <div
-          className="pointer-events-auto flex flex-wrap items-center gap-6
-                     bg-[--walty-cream]/95 backdrop-blur shadow-lg rounded-xl
-                     border border-[rgba(0,91,85,.2)] px-4 py-3
-                     max-w-[720px] w-[calc(100%-6rem)]"
+          className="
+            pointer-events-auto flex flex-nowrap items-center gap-4
+            bg-[--walty-cream]/95 backdrop-blur shadow-lg rounded-xl
+            border border-[rgba(0,91,85,.2)] px-4 py-2
+            max-w-none w-[calc(100%-2rem)]]"
         >
+          {/* ───────── Font family & size (no captions) ───────── */}
+          <FontFamilySelect
+            disabled={!tb}
+            value={tb?.fontFamily ?? 'Arial'}
+            onChange={(v: string) => mutate({ fontFamily: v })}
+          />
+          <FontSizeStepper
+            disabled={!tb}
+            value={tb?.fontSize ?? 12}
+            onChange={(v: number) => mutate({ fontSize: v })}
+          />
 
-          {/* Add text */}
-          <IconButton Icon={Type} label="Add text" caption="Text" onClick={addText} />
+          {/* colour swatch */}
+          <input
+            disabled={!tb}
+            type="color"
+            value={tb ? (tb.fill as string) : '#000000'}
+            onChange={e => mutate({ fill: e.target.value })}
+            className="h-10 w-10 border rounded disabled:opacity-40"
+          />
 
+          {/* centre on page */}
+          <IconButton 
+            Icon={AlignToPageVertical}
+            label="Center vertical"
+            caption="Center Y"
+            onClick={cycleVertical}
+            disabled={!tb}
+          />
+          <IconButton 
+            Icon={AlignToPageHorizontal}
+            label="Center horizontal"
+            caption="Center X"
+            onClick={cycleHorizontal}
+            disabled={!tb}
+          />
 
-          {/* font family */}
-          <select disabled={!tb} value={tb?.fontFamily ?? fonts[0]}
-                  onChange={e=>mutate({fontFamily:e.target.value})}
-                  className="border p-1 rounded min-w-[8rem] disabled:opacity-40">
-            {fonts.map(f=><option key={f}>{f}</option>)}
-          </select>
+          {/* lock / unlock */}
+          <IconButton 
+            Icon={locked ? Lock : Unlock}
+            label={locked ? 'Unlock layer' : 'Lock layer'}
+            active={locked}
+            onClick={toggleLock}
+            disabled={!tb}
+          />
 
-          {/* font size */}
-          <div className="flex items-center">
-            <button disabled={!tb} onClick={()=>mutate({fontSize:Math.max(10,(tb!.fontSize??12)-4)})}
-                    className="toolbar-btn rounded-l">−</button>
-            <input disabled={!tb} type="number" value={tb?.fontSize ?? ''}
-                   onChange={e=>mutate({fontSize:+e.target.value})}
-                   className="w-14 border-t border-b p-1 text-center disabled:opacity-40"/>
-            <button disabled={!tb} onClick={()=>mutate({fontSize:(tb!.fontSize??12)+4})}
-                    className="toolbar-btn rounded-r">+</button>
-          </div>
-
-          {/* colour */}
-          <input disabled={!tb} type="color" value={tb ? tb.fill as string : '#000000'}
-                 onChange={e=>mutate({fill:e.target.value})}
-                 className="disabled:opacity-40 h-8 w-8 border p-0"/>
+          {/* send backward / bring forward */}
+          <IconButton 
+            Icon={ArrowDownToLine}
+            label="Send backward"
+            caption="Send ↓"
+            onClick={sendBackward}
+            disabled={!tb}
+          />
+          <IconButton 
+            Icon={ArrowUpToLine}
+            label="Bring forward"
+            caption="Bring ↑"
+            onClick={bringForward}
+            disabled={!tb}
+          />
 
           {/* B / I / U */}
-          <IconButton
+          <IconButton 
             Icon={Bold}
             label="Bold"
-            onClick={() => mutate({ fontWeight: tb!.fontWeight === 'bold' ? 'normal' : 'bold' })}
+            onClick={() =>
+              mutate({ fontWeight: tb!.fontWeight === 'bold' ? 'normal' : 'bold' })}
             active={tb?.fontWeight === 'bold'}
             disabled={!tb}
           />
-          <IconButton
+          <IconButton 
             Icon={Italic}
             label="Italic"
-            onClick={() => mutate({ fontStyle: tb!.fontStyle === 'italic' ? 'normal' : 'italic' })}
+            onClick={() =>
+              mutate({ fontStyle: tb!.fontStyle === 'italic' ? 'normal' : 'italic' })}
             active={tb?.fontStyle === 'italic'}
             disabled={!tb}
           />
-          <IconButton
+          <IconButton 
             Icon={Underline}
             label="Underline"
             onClick={() => mutate({ underline: !tb!.underline })}
@@ -141,28 +250,35 @@ export default function TextToolbar(props:Props){
             disabled={!tb}
           />
 
-          {/* text case cycle */}
-          <IconButton
-            Icon={caseState === 'upper' ? CaseUpper : caseState === 'title' ? CaseSensitive : CaseLower}
+          {/* text-case cycle */}
+          <IconButton 
+            Icon={
+              caseState === 'upper'
+                ? CaseUpper
+                : caseState === 'title'
+                  ? CaseSensitive
+                  : CaseLower
+            }
             label="Change case"
+            caption="Case"
             onClick={() => {
-              if (!tb) return;
+              if (!tb) return
               if (caseState === 'upper') {
-                mutate({ text: tb!.text!.toUpperCase() });
-                setCaseState('title');
+                mutate({ text: tb.text!.toUpperCase() })
+                setCaseState('title')
               } else if (caseState === 'title') {
-                mutate({ text: tb!.text!.replace(/\b\w/g, c => c.toUpperCase()) });
-                setCaseState('lower');
+                mutate({ text: tb.text!.replace(/\b\w/g, c => c.toUpperCase()) })
+                setCaseState('lower')
               } else {
-                mutate({ text: tb!.text!.toLowerCase() });
-                setCaseState('upper');
+                mutate({ text: tb.text!.toLowerCase() })
+                setCaseState('upper')
               }
             }}
             disabled={!tb}
           />
 
-          {/* align */}
-          <IconButton
+          {/* align cycle */}
+          <IconButton 
             Icon={
               (tb?.textAlign ?? 'left') === 'left'
                 ? AlignLeft
@@ -177,7 +293,7 @@ export default function TextToolbar(props:Props){
             disabled={!tb}
           />
 
-          {/* line-height */}
+          {/* line-height input */}
           <input
             disabled={!tb}
             type="number"
@@ -186,11 +302,17 @@ export default function TextToolbar(props:Props){
             max={3}
             value={tb?.lineHeight ?? ''}
             onChange={e => mutate({ lineHeight: +e.target.value })}
-            className="w-16 border p-1 rounded disabled:opacity-40"
+            title="Line height"
+            className="
+              w-16 h-12 px-2 border rounded disabled:opacity-40
+              focus-visible:outline-none focus-visible:ring-2
+              focus-visible:ring-teal-400/50
+            "
           />
 
-          {/* opacity */}
+          {/* opacity slider */}
           <ToolTextOpacitySlider tb={tb} mutate={mutate} />
+
         </div>
       )}
 

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -7,6 +7,21 @@
 import { useEffect, useState } from 'react'
 import { fabric }              from 'fabric'
 import { getActiveTextbox }    from './FabricCanvas'
+import IconButton              from './toolbar/IconButton'
+import ToolTextOpacitySlider   from './toolbar/ToolTextOpacitySlider'
+import {
+  Type,
+  Bold,
+  Italic,
+  Underline,
+  CaseUpper,
+  CaseLower,
+  CaseSensitive,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  AlignJustify,
+} from 'lucide-react'
 
 type Mode = 'staff'|'customer'
 const fonts = ['Arial','Georgia','monospace','Dingos Stamp']
@@ -65,19 +80,19 @@ export default function TextToolbar(props:Props){
 
   /* ---------------------------------------------------------------- */
   return (
-    <div className="fixed top-0 inset-x-0 z-30 flex justify-center pointer-events-none select-none">
+    <div className="fixed inset-x-0 top-2 z-30 flex justify-center pointer-events-none select-none">
 
       {/* ───────── ① MAIN TOOLBAR (staff only) ───────── */}
       {mode==='staff' && (
-        <div className="toolbar pointer-events-auto flex flex-wrap items-center gap-2
-                        border bg-white/95 backdrop-blur rounded-md shadow px-3 py-1
-                        max-w-[800px] w-[calc(100%-10rem)]">
+        <div
+          className="pointer-events-auto flex flex-wrap items-center gap-6
+                     bg-[--walty-cream]/95 backdrop-blur shadow-lg rounded-xl
+                     border border-[rgba(0,91,85,.2)] px-4 py-3
+                     max-w-[720px] w-[calc(100%-6rem)]"
+        >
 
-          {/* +Text */}
-          <button onClick={addText} className="px-3 py-1 rounded bg-blue-600 text-white
-                                               shrink-0 hover:bg-blue-700 active:bg-blue-800">
-            + Text
-          </button>
+          {/* Add text */}
+          <IconButton Icon={Type} label="Add text" caption="Text" onClick={addText} />
 
 
           {/* font family */}
@@ -104,63 +119,81 @@ export default function TextToolbar(props:Props){
                  className="disabled:opacity-40 h-8 w-8 border p-0"/>
 
           {/* B / I / U */}
-          <button disabled={!tb} onClick={()=>mutate({fontWeight:tb!.fontWeight==='bold'?'normal':'bold'})}
-                  className="toolbar-btn font-bold">B</button>
-          <button disabled={!tb} onClick={()=>mutate({fontStyle:tb!.fontStyle==='italic'?'normal':'italic'})}
-                  className="toolbar-btn italic">I</button>
-          <button disabled={!tb} onClick={()=>mutate({underline:!tb!.underline})}
-                  className="toolbar-btn underline">U</button>
+          <IconButton
+            Icon={Bold}
+            label="Bold"
+            onClick={() => mutate({ fontWeight: tb!.fontWeight === 'bold' ? 'normal' : 'bold' })}
+            active={tb?.fontWeight === 'bold'}
+            disabled={!tb}
+          />
+          <IconButton
+            Icon={Italic}
+            label="Italic"
+            onClick={() => mutate({ fontStyle: tb!.fontStyle === 'italic' ? 'normal' : 'italic' })}
+            active={tb?.fontStyle === 'italic'}
+            disabled={!tb}
+          />
+          <IconButton
+            Icon={Underline}
+            label="Underline"
+            onClick={() => mutate({ underline: !tb!.underline })}
+            active={!!tb?.underline}
+            disabled={!tb}
+          />
 
           {/* text case cycle */}
-          <button
-            disabled={!tb}
+          <IconButton
+            Icon={caseState === 'upper' ? CaseUpper : caseState === 'title' ? CaseSensitive : CaseLower}
+            label="Change case"
             onClick={() => {
-              if (!tb) return
+              if (!tb) return;
               if (caseState === 'upper') {
-                mutate({ text: tb!.text!.toUpperCase() })
-                setCaseState('title')
+                mutate({ text: tb!.text!.toUpperCase() });
+                setCaseState('title');
               } else if (caseState === 'title') {
-                mutate({ text: tb!.text!.replace(/\b\w/g, c => c.toUpperCase()) })
-                setCaseState('lower')
+                mutate({ text: tb!.text!.replace(/\b\w/g, c => c.toUpperCase()) });
+                setCaseState('lower');
               } else {
-                mutate({ text: tb!.text!.toLowerCase() })
-                setCaseState('upper')
+                mutate({ text: tb!.text!.toLowerCase() });
+                setCaseState('upper');
               }
             }}
-            className="toolbar-btn">
-            {caseState === 'upper' ? 'AA' : caseState === 'title' ? 'Aa' : 'aa'}
-          </button>
+            disabled={!tb}
+          />
 
           {/* align */}
-          <button
-            disabled={!tb}
+          <IconButton
+            Icon={
+              (tb?.textAlign ?? 'left') === 'left'
+                ? AlignLeft
+                : (tb?.textAlign ?? 'left') === 'center'
+                  ? AlignCenter
+                  : (tb?.textAlign ?? 'left') === 'right'
+                    ? AlignRight
+                    : AlignJustify
+            }
+            label="Align"
             onClick={cycleAlign}
-            className="toolbar-btn">
-            {alignSymbols[tb?.textAlign ?? 'left']}
-          </button>
+            disabled={!tb}
+          />
 
           {/* line-height */}
-          <input disabled={!tb} type="number" step={0.1} min={0.5} max={3}
-                 value={tb?.lineHeight ?? ''}
-                 onChange={e=>mutate({lineHeight:+e.target.value})}
-                 className="w-16 border p-1 rounded disabled:opacity-40"/>
+          <input
+            disabled={!tb}
+            type="number"
+            step={0.1}
+            min={0.5}
+            max={3}
+            value={tb?.lineHeight ?? ''}
+            onChange={e => mutate({ lineHeight: +e.target.value })}
+            className="w-16 border p-1 rounded disabled:opacity-40"
+          />
 
           {/* opacity */}
-          <input disabled={!tb} type="range" min={0} max={1} step={0.01}
-                 value={tb?.opacity ?? 1}
-                 onChange={e=>mutate({opacity:+e.target.value})}
-                 className="disabled:opacity-40"/>
+          <ToolTextOpacitySlider tb={tb} mutate={mutate} />
         </div>
       )}
 
     </div>
   )
-}
-
-/* inject one-off tiny CSS (only once) */
-if(typeof window!=='undefined' && !document.getElementById('toolbar-css')){
-  const shared='border px-2 py-[2px] rounded hover:bg-gray-100 disabled:opacity-40'
-  const style=document.createElement('style'); style.id='toolbar-css'
-  style.innerHTML=`.toolbar-btn{${shared}}`
-  document.head.appendChild(style)
 }

--- a/app/components/toolbar/FontFamilySelect.tsx
+++ b/app/components/toolbar/FontFamilySelect.tsx
@@ -1,0 +1,30 @@
+// app/components/toolbar/FontFamilySelect.tsx
+'use client'
+
+import type { ChangeEvent } from 'react'
+
+interface Props {
+  value    : string
+  onChange : (v: string) => void
+  disabled : boolean
+}
+
+export function FontFamilySelect ({ value, onChange, disabled }: Props) {
+  return (
+    <select
+      value={value}
+      disabled={disabled}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
+      className="
+        h-12 min-w-[9rem] px-2 rounded-lg
+        bg-white/80 border border-teal-800/10 text-sm
+        disabled:opacity-40
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50
+      "
+    >
+      {['Arial', 'Georgia', 'monospace', 'Dingos Stamp'].map(f => (
+        <option key={f}>{f}</option>
+      ))}
+    </select>
+  )
+}

--- a/app/components/toolbar/FontSizeStepper.tsx
+++ b/app/components/toolbar/FontSizeStepper.tsx
@@ -1,0 +1,47 @@
+// app/components/toolbar/FontSizeStepper.tsx
+'use client'
+
+interface Props {
+  value    : number
+  onChange : (v: number) => void
+  disabled : boolean
+}
+
+export function FontSizeStepper ({ value, onChange, disabled }: Props) {
+  return (
+    <div className="flex h-12">
+      <button
+        disabled={disabled}
+        onClick={() => onChange(Math.max(4, value - 4))}
+        className="
+          w-12 rounded-l-lg border border-r-0 border-teal-800/10
+          enabled:hover:bg-teal-50 disabled:opacity-40
+        "
+      >
+        −
+      </button>
+
+      <input
+        disabled={disabled}
+        type="number"
+        value={value}
+        onChange={e => onChange(+e.target.value)}
+        className="
+          w-16 h-12 text-center border-y border-teal-800/10
+          disabled:opacity-40
+        "
+      />
+
+      <button
+        disabled={disabled}
+        onClick={() => onChange(value + 4)}
+        className="
+          w-12 rounded-r-lg border border-l-0 border-teal-800/10
+          enabled:hover:bg-teal-50 disabled:opacity-40
+        "
+      >
+        +
+      </button>
+    </div>
+  )
+}

--- a/app/components/toolbar/IconButton.tsx
+++ b/app/components/toolbar/IconButton.tsx
@@ -1,56 +1,63 @@
-// IconButton.tsx
-"use client";
-import { forwardRef } from "react";
+// components/toolbar/IconButton.tsx
+'use client'
+
+import { forwardRef } from 'react'
 
 interface IconBtnProps {
-  Icon:  React.ElementType;
-  label: string;           // full tooltip / aria label
-  caption?: string;        // 1-2-word text under the icon (defaults to first word of label)
-  onClick: () => void;
-  active?: boolean;
-  disabled?: boolean;
+  Icon        : React.ElementType
+  label       : string
+  caption?    : string
+  onClick     : () => void
+  active?     : boolean
+  disabled?   : boolean
+  hideCaption?: boolean
+  size?       : 'lg' | 'sm'        // ← NEW (default "lg")
 }
 
-/**
- * Toolbar icon button — 48 px square hit-area with 24 px icon
- * and 11 px caption text. Forward-refs the underlying button so
- * popovers can anchor to it.
- */
 const IconButton = forwardRef<HTMLButtonElement, IconBtnProps>(
   (
-    { Icon, label, caption = label.split(" ")[0], onClick, active, disabled },
-    ref
-  ) => (
-    <button
-      ref={ref}
-      type="button"
-      aria-label={label}
-      title={label}
-      onClick={onClick}
-      disabled={disabled}
-      className={`flex flex-col items-center justify-center w-12 p-2 gap-0.5
-                  rounded focus:outline-none
-                  focus:ring-2 focus:ring-[--walty-orange] focus:ring-offset-1
-                  hover:bg-[--walty-orange]/10 disabled:opacity-40
-                  ${active ? "bg-[--walty-orange]/10" : ""}`}
-    >
-      {/* icon */}
-      <Icon
-        className={`w-6 h-6 stroke-[--walty-teal] transition-colors
-                    ${active ? "stroke-[--walty-orange]"
-                              : "hover:stroke-[--walty-orange]"}`}
-      />
-      {/* caption */}
-      <span
-        className={`text-[11px] leading-none font-medium tracking-wide
-                    ${active ? "text-[--walty-orange]"
-                              : "text-[--walty-teal]"}`}
-      >
-        {caption}
-      </span>
-    </button>
-  )
-);
-IconButton.displayName = "IconButton";
+    {
+      Icon,
+      label,
+      caption     = label.split(' ')[0],
+      onClick,
+      active      = false,
+      disabled    = false,
+      hideCaption = false,
+      size        = 'lg',
+    },
+    ref,
+  ) => {
+    const isSm   = size === 'sm'
+    const btnCls = isSm ? 'h-10 w-10' : 'h-12 w-12'   // 40 px vs 48 px
+    const icnCls = isSm ? 'h-5 w-5'  : 'h-6 w-6'      // 20 px vs 24 px
+    const txtCls = isSm ? 'text-[10px]' : 'text-[11px]'
 
-export default IconButton;
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-label={label}
+        title={label}
+        onClick={onClick}
+        disabled={disabled}
+        className={`
+          flex flex-col items-center justify-center gap-0.5
+          ${btnCls} rounded-lg transition
+          ${active ? 'bg-[--walty-orange]/10 text-[--walty-orange]' : 'text-[--walty-teal]'}
+          enabled:hover:bg-[--walty-orange]/10 enabled:hover:text-[--walty-orange]    
+          disabled:opacity-40
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50
+        `}
+      >
+        <Icon className={`${icnCls} stroke-[2] ${active ? 'stroke-[--walty-orange]' : 'enabled:hover:stroke-[--walty-orange]'}`} />
+        {!hideCaption && (
+          <span className={`${txtCls} leading-none`}>{caption}</span>
+        )}
+      </button>
+    )
+  },
+)
+
+IconButton.displayName = 'IconButton'
+export default IconButton

--- a/app/components/toolbar/ToolTextOpacitySlider.tsx
+++ b/app/components/toolbar/ToolTextOpacitySlider.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { useRef, useState } from "react";
+import { fabric } from "fabric";
+import { Droplet } from "lucide-react";
+import Popover from "./Popover";
+import IconButton from "./IconButton";
+
+interface Props {
+  tb: fabric.Textbox | null;
+  mutate: (p: Partial<fabric.Textbox>) => void;
+}
+
+export default function ToolTextOpacitySlider({ tb, mutate }: Props) {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  const handleChange = (v: number) => {
+    if (!tb) return;
+    mutate({ opacity: v });
+  };
+
+  return (
+    <>
+      <IconButton
+        ref={btnRef}
+        Icon={Droplet}
+        label="Opacity"
+        active={open}
+        disabled={!tb}
+        onClick={() => tb && setOpen(o => !o)}
+      />
+
+      <Popover anchor={btnRef.current} open={open && !!tb} onClose={() => setOpen(false)}>
+        <label htmlFor="text-opacity-slider" className="sr-only">
+          Text opacity
+        </label>
+        <input
+          id="text-opacity-slider"
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={tb?.opacity ?? 1}
+          onChange={e => handleChange(e.target.valueAsNumber)}
+          className="w-52 accent-[--walty-orange]"
+        />
+      </Popover>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- restyle TextToolbar to match ImageToolbar look
- represent text actions with lucide icons
- provide a popover opacity slider via new ToolTextOpacitySlider component

## Testing
- `npm run lint` *(fails: React Hooks and other lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_683b6ea101c88323b7b38f1645a8022f