### PR TITLE
Fix thumbnail background and toolbar lag

### DIFF
--- a/app/components/EditorStore.ts
+++ b/app/components/EditorStore.ts
@@ -209,12 +209,11 @@ export const useEditor = create<EditorState>((set, get) => ({
 
   /* live edits coming back from FabricCanvas ---------------------- */
   updateLayer: (pageIdx, idx, data) => {
-    const { pages, pushHistory } = get()
-    const nextPages = clone(pages)
-
-    Object.assign(nextPages[pageIdx].layers[idx] ?? {}, data)
-    set({ pages: nextPages })
-    pushHistory()
+    set(state => {
+      const pages = clone(state.pages)
+      Object.assign(pages[pageIdx].layers[idx] ?? {}, data)
+      return { pages }
+    })
   },
 
   /* drag-to-reorder in LayerPanel --------------------------------- */

--- a/app/globals.css
+++ b/app/globals.css
@@ -38,7 +38,7 @@ body {
 html { @apply bg-white text-gray-900; }
 
 /* Thumbnail + toolbar */
-.thumb        { @apply border-gray-300 bg-white text-xs w-24 h-32 p-1; }
+.thumb        { @apply border-gray-300 bg-white dark:bg-white text-xs w-24 h-32 p-1; }
 .thumb-active { @apply ring-2 ring-blue-600; }
 .toolbar      { @apply bg-white/90 backdrop-blur shadow text-gray-900; }
 


### PR DESCRIPTION
## Summary
- ensure thumbnails have a white background even in dark mode
- speed up live updates from toolbar edits

## Testing
- `npm run lint` *(fails: React Hook issues)*

------
https://chatgpt.com/codex/tasks/task_e_683babb168508323ae2434c587271324