### PR TITLE
Update thumbnails after canvas render

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -117,8 +117,13 @@ export default function CardEditor({
   }
 
   useEffect(() => {
-    canvasMap.forEach((_, i) => updateThumb(i))
-  }, [canvasMap])
+    const handler = (e: Event) => {
+      const idx = (e as CustomEvent<{ pageIdx: number }>).detail?.pageIdx
+      if (typeof idx === 'number') updateThumb(idx)
+    }
+    document.addEventListener('card-canvas-rendered', handler)
+    return () => document.removeEventListener('card-canvas-rendered', handler)
+  }, [])
 
   useEffect(() => {
     updateThumb(activeIdx)

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -973,7 +973,11 @@ img.on('mouseup', () => {
 
     addGuides(fc)
     hoverRef.current?.bringToFront()
-    fc.requestRenderAll(); hydrating.current = false
+    fc.requestRenderAll();
+    hydrating.current = false
+    document.dispatchEvent(
+      new CustomEvent('card-canvas-rendered', { detail: { pageIdx } })
+    )
   }, [page])
 
   /* ---------- render ----------------------------------------- */


### PR DESCRIPTION
## Summary
- trigger `card-canvas-rendered` when FabricCanvas finishes rendering a page
- listen for `card-canvas-rendered` in CardEditor to update thumbnails
- drop eager thumbnail generation on canvas initialization

## Testing
- `npm run lint` *(fails: React hook rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_683c773792f8832390dd8130271db7be