### PR TITLE
Fix preview thumbnails in card editor

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -126,6 +126,12 @@ export default function CardEditor({
   }, [])
 
   useEffect(() => {
+    canvasMap.forEach((fc, idx) => {
+      if (fc && !thumbs[idx]) updateThumb(idx)
+    })
+  }, [canvasMap])
+
+  useEffect(() => {
     updateThumb(activeIdx)
   }, [pages, activeIdx])
 

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -822,7 +822,10 @@ document.addEventListener('start-crop', cropListener)
     if (isEditing.current || (fc as any)._editingRef?.current) return
 
     hydrating.current = true
-    fc.clear(); hoverRef.current && fc.add(hoverRef.current)
+    fc.clear();
+    fc.setBackgroundColor('#fff', undefined, {dirty: true});
+    addBackdrop(fc);
+    hoverRef.current && fc.add(hoverRef.current)
 
     /* bottom ➜ top keeps original z-order */
     for (let idx = page.layers.length - 1; idx >= 0; idx--) {


### PR DESCRIPTION
## Summary
- re-add white backdrop when pages are redrawn so JPEG thumbnails don't show black
- generate initial thumbnails once canvases are ready

## Testing
- `npm run lint` *(fails: react-hooks errors, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683c7df22b9483238d98a1231fc591c2