### PR TITLE
Fix thumbnail rendering

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -105,6 +105,7 @@ export default function CardEditor({
     const fc = canvasMap[idx]
     if (!fc) return
     try {
+      fc.renderAll()
       const url = fc.toDataURL({ format: 'jpeg', quality: 0.8 })
       setThumbs(prev => {
         const next = [...prev]

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -946,6 +946,10 @@ img.on('mouseup', () => {
             (o as any).layerIdx !== undefined && (o as any).layerIdx < idx)
           fc.insertAt(img, pos === -1 ? fc.getObjects().length : pos, false)
           img.setCoords()
+          fc.requestRenderAll()
+          document.dispatchEvent(
+            new CustomEvent('card-canvas-rendered', { detail: { pageIdx } })
+          )
         }, opts)
         continue
       }

--- a/app/globals.css
+++ b/app/globals.css
@@ -38,7 +38,7 @@ body {
 html { @apply bg-white text-gray-900; }
 
 /* Thumbnail + toolbar */
-.thumb        { @apply border-gray-300 bg-white text-xs w-[140px] h-[210px] p-1; }
+.thumb        { @apply border-gray-300 bg-white text-xs w-[140px] h-[197px] p-1; }
 .thumb img    { background-color:#fff; }
 .thumb-active { @apply ring-2 ring-blue-600; }
 .toolbar      { @apply bg-white/90 backdrop-blur shadow text-gray-900; }


### PR DESCRIPTION
## Summary
- match thumbnail aspect ratio with design
- refresh Fabric thumbnails immediately on image load
- render thumbnail after canvas render

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ca0b0727c8323acb206475340439c