### PR TITLE
Fix preview blank on reload

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -7,7 +7,7 @@
  *********************************************************************/
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useLayoutEffect } from 'react'
 import { fabric }                       from 'fabric'
 
 import { useEditor }                    from './EditorStore'
@@ -117,7 +117,7 @@ export default function CardEditor({
     }
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const handler = (e: Event) => {
       const idx = (e as CustomEvent<{ pageIdx: number }>).detail?.pageIdx
       if (typeof idx === 'number') updateThumb(idx)


### PR DESCRIPTION
## Summary
- ensure the preview event listener registers before Fabric canvas events

## Testing
- `npm run lint` *(fails: React hooks rules and other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ca5697df08323925d0b6c42066acd