### PR TITLE
Restyle thumbnail bar

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -8,6 +8,7 @@
 'use client'
 
 import { useEffect, useRef, useState, useLayoutEffect } from 'react'
+import { GripVertical }                   from 'lucide-react'
 import { fabric }                       from 'fabric'
 
 import { useEditor }                    from './EditorStore'
@@ -349,14 +350,14 @@ const handleSwap = (url: string) => {
         </div>
 
         {/* thumbnails */}
-        <div className="flex justify-center gap-2 p-3 bg-gray-50 dark:bg-gray-800 text-xs">
+        <div className="scrollbar-hidden flex h-[112px] items-center overflow-x-auto gap-3 px-4 py-3 bg-[--walty-cream] text-walty-teal shadow-[0_-2px_4px_rgba(0,0,0,0.08)]">
           {(['FRONT', 'INNER-L', 'INNER-R', 'BACK'] as const).map((lbl, i) => (
             <button
               key={lbl}
-              className={`thumb ${
-                (section === 'front'  && i === 0) ||
+              className={`thumb group ${
+                (section === 'front' && i === 0) ||
                 (section === 'inside' && (i === 1 || i === 2)) ||
-                (section === 'back'   && i === 3)
+                (section === 'back' && i === 3)
                   ? 'thumb-active'
                   : ''
               }`}
@@ -364,14 +365,11 @@ const handleSwap = (url: string) => {
                 setSection(i === 0 ? 'front' : i === 3 ? 'back' : 'inside')
               }
             >
+              <GripVertical className="absolute right-1 top-1 h-6 w-6 stroke-[1.5] text-walty-teal opacity-0 transition-opacity group-hover:opacity-100" />
               {thumbs[i] ? (
-                <img
-                  src={thumbs[i]}
-                  alt={lbl}
-                  className="h-full w-full object-cover"
-                />
+                <img src={thumbs[i]} alt={lbl} className="h-full w-full object-cover rounded" />
               ) : (
-                lbl
+                <span className="truncate">{lbl}</span>
               )}
             </button>
           ))}

--- a/app/globals.css
+++ b/app/globals.css
@@ -38,9 +38,15 @@ body {
 html { @apply bg-white text-gray-900; }
 
 /* Thumbnail + toolbar */
-.thumb        { @apply border-gray-300 bg-white text-xs w-[140px] h-[197px] p-1; }
-.thumb img    { background-color:#fff; }
-.thumb-active { @apply ring-2 ring-blue-600; }
+.thumb {
+  @apply relative flex h-[84px] w-[60px] flex-shrink-0 items-center justify-center rounded border border-walty-teal/40 bg-white px-2 py-1 text-[0.875rem] text-walty-teal/90 hover:border-walty-teal;
+}
+.thumb img {
+  @apply h-full w-full rounded object-cover;
+}
+.thumb-active {
+  @apply border-walty-orange bg-walty-orange/20;
+}
 .toolbar      { @apply bg-white/90 backdrop-blur shadow text-gray-900; }
 
 /* === AI placeholder ghost ===================================== */


### PR DESCRIPTION
## Summary
- import `GripVertical` icon
- update thumbnail styles in globals
- redesign thumbnail bar layout and item styling

## Testing
- `npm run lint` *(fails: React hooks and img warnings)*

------
https://chatgpt.com/codex/tasks/task_e_683cb978cb708323813c7520e798862f