### PR TITLE
Keep crop handles visible

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -311,10 +311,10 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
     imgDown   : (e: fabric.IEvent) => void
     imgUp     : (e: fabric.IEvent) => void
     frameDown : (e: fabric.IEvent) => void
-    frameUp   : (e: fabric.IEvent) => void
     clamp     : () => void
     clampFrame: () => void
     frameMove : () => void
+    renderCropControls: () => void
   }
   const cropHandlersRef = useRef<CropHandlers | null>(null)
   const cropGroupRef  = useRef<fabric.Group | null>(null)
@@ -499,6 +499,17 @@ const startCrop = (img: fabric.Image) => {
   cropGroupRef.current = frame;
   fc.add(frame);
 
+  const renderCropControls = () => {
+    if (!croppingRef.current) return
+    if (cropGroupRef.current) {
+      cropGroupRef.current.drawControls((fc as any).contextTop)
+    }
+    if (cropImgRef.current) {
+      cropImgRef.current.drawControls((fc as any).contextTop)
+    }
+  }
+  fc.on('after:render', renderCropControls);
+
   /* clamp the crop frame so it never extends beyond the image */
   const clampFrame = () => {
 
@@ -548,7 +559,6 @@ const startCrop = (img: fabric.Image) => {
   fc.setActiveObject(frame)
   updateMaskAround(frame)
 
-  const keepFrameActive = () => { fc.setActiveObject(frame); updateMaskAround(frame) }
   const frameMove = () => {
     const dx = frame.left! - fixedLeft;
     const dy = frame.top!  - fixedTop;
@@ -559,12 +569,12 @@ const startCrop = (img: fabric.Image) => {
     }
   }
   const imgDown   = () => fc.setActiveObject(img)
-  const imgUp     = keepFrameActive
+  const imgUp     = () => {}
   const frameDown = (e: fabric.IEvent) => {
     const corner = (e as any).transform?.corner
     if (!corner) fc.setActiveObject(img)
   }
-  const frameUp   = keepFrameActive
+  const frameUp   = () => {}
 
   img.on('moving', clamp)
      .on('scaling', clamp)
@@ -575,7 +585,15 @@ const startCrop = (img: fabric.Image) => {
        .on('mouseup', frameUp)
        .on('moving', frameMove)
 
-  cropHandlersRef.current = { imgDown, imgUp, frameDown, frameUp, clamp, clampFrame, frameMove }
+  cropHandlersRef.current = {
+    imgDown,
+    imgUp,
+    frameDown,
+    clamp,
+    clampFrame,
+    frameMove,
+    renderCropControls,
+  }
 };
 
 /* ---------- cancelCrop (unchanged) ---------------------------- */
@@ -594,9 +612,9 @@ const cancelCrop = () => {
   if (frame && handlers) {
     frame.off('scaling', handlers.clampFrame)
          .off('mousedown', handlers.frameDown)
-         .off('mouseup', handlers.frameUp)
          .off('moving', handlers.frameMove)
   }
+  if (handlers) fc.off('after:render', handlers.renderCropControls)
   cropHandlersRef.current = null
   fc.remove(cropGroupRef.current!); clearMask();
 
@@ -631,8 +649,8 @@ const commitCrop = () => {
      .off('mouseup', handlers?.imgUp)
   frame.off('scaling', handlers?.clampFrame)
        .off('mousedown', handlers?.frameDown)
-       .off('mouseup', handlers?.frameUp)
        .off('moving', handlers?.frameMove)
+  if (handlers) fc.off('after:render', handlers.renderCropControls)
   cropHandlersRef.current = null
   fc.remove(frame); clearMask();
 


### PR DESCRIPTION
## Summary
- keep crop frame controls visible via an after:render listener
- clean up crop handler registration and teardown
- allow image to stay active while cropping
- draw image controls alongside the crop frame so both sets remain visible

## Testing
- `npm run lint` *(fails: React Hook and other existing errors)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing modules and type errors)*


------
https://chatgpt.com/codex/tasks/task_e_683cc50abba48323afbcb1d004f9172a