### PR TITLE
Update editor palette

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -207,7 +207,7 @@ const handleSwap = (url: string) => {
 
   /* ---------------- UI ------------------------------------------ */
   return (
-    <div className="flex h-screen relative">
+    <div className="flex h-screen relative bg-[--walty-cream]">
 
       {/* global overlays */}
       <CoachMark

--- a/app/components/EditorCommands.tsx
+++ b/app/components/EditorCommands.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export default function EditorCommands({ onUndo, onRedo, onSave, saving }: Props) {
   return (
-    <div className="fixed right-4 top-2 z-40 flex gap-3 pointer-events-auto select-none">
+    <div className="fixed right-4 top-2 z-40 flex gap-3 pointer-events-auto select-none bg-white shadow rounded-md px-3 py-2">
       <IconButton Icon={RotateCcw} label="Undo" onClick={onUndo} />
       <IconButton Icon={RotateCw} label="Redo" onClick={onRedo} />
       <button

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -982,7 +982,7 @@ img.on('mouseup', () => {
       ref={canvasRef}
       width={PREVIEW_W}
       height={PREVIEW_H}
-      className="border w-full h-auto max-w-[420px]"
+      className="border w-full h-auto max-w-[420px] shadow"
     />
   )
 }

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -138,7 +138,7 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
       {/* main bar */}
       <div
         className="pointer-events-auto flex flex-nowrap items-center gap-6
-                   bg-[--walty-cream]/95 backdrop-blur shadow-lg rounded-xl
+                   bg-white shadow-lg rounded-xl
                    border border-[rgba(0,91,85,.2)] px-4 py-3 max-w-[720px] w-[calc(100%-6rem)]"
       >
         <IconButton Icon={Crop} label="Crop" onClick={() => document.dispatchEvent(new Event("start-crop"))} />

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -99,7 +99,7 @@ export default function LayerPanel() {
 
   return (
     <aside
-      className={`fixed left-0 top-0 z-20 h-full w-60 bg-[--walty-cream] shadow-lg transition-transform duration-300 ${
+      className={`fixed left-0 top-0 z-20 h-full w-60 bg-white shadow-lg transition-transform duration-300 ${
         open ? "translate-x-0" : "-translate-x-56"
       }`}
     >

--- a/app/components/SelfieDrawer.tsx
+++ b/app/components/SelfieDrawer.tsx
@@ -195,7 +195,7 @@ export default function SelfieDrawer ({
         >
           <div className="ml-auto w-[340px] max-w-full h-full bg-white shadow-xl flex flex-col">
             {/* header */}
-            <div className="flex items-center justify-between bg-gray-800 text-white px-4 py-3">
+            <div className="flex items-center justify-between bg-white shadow px-4 py-3">
               <h2 className="text-sm font-medium">
                 {phase === 'generating' ? 'Generating your images' : 'Selfie Drawer'}
               </h2>

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -159,7 +159,7 @@ export default function TextToolbar (props: Props) {
         <div
           className="
             pointer-events-auto flex flex-nowrap items-center gap-4
-            bg-[--walty-cream]/95 backdrop-blur shadow-lg rounded-xl
+            bg-white shadow-lg rounded-xl
             border border-[rgba(0,91,85,.2)] px-4 py-2
             max-w-none w-[calc(100%-2rem)]]"
         >

--- a/app/components/toolbar/Popover.tsx
+++ b/app/components/toolbar/Popover.tsx
@@ -53,9 +53,9 @@ export default function Popover({ anchor, open, onClose, children }: Props) {
     <div
       ref={ref}
       style={style}
-      className="min-w-40 rounded-xl bg-[--walty-cream]/95
+      className="min-w-40 rounded-xl bg-white
                  px-3 py-2 shadow-lg ring-1 ring-walty-brown/15
-                 backdrop-blur animate-pop"
+                 animate-pop"
     >
       {children}
     </div>,

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
 
 /* ❶  Design tokens (light‑mode only) */
 :root {
-  --background: #ffffff;
+  --background: var(--walty-cream);
   --foreground: #171717;
   --walty-cream : #F7F3EC;
   --walty-teal  : #005B55;
@@ -35,7 +35,7 @@ body {
    Tailwind utility tweaks (light‑mode only)
 ──────────────────────────────────────────────────────────────── */
 
-html { @apply bg-white text-gray-900; }
+html { @apply bg-[--walty-cream] text-gray-900; }
 
 /* Thumbnail + toolbar */
 .thumb        { @apply border-gray-300 bg-white text-xs w-24 h-32 p-1; }


### PR DESCRIPTION
## Summary
- brand background on CardEditor
- white backgrounds and shadows across UI panels
- make Fabric canvas white and shadowed
- set page background to walty cream

## Testing
- `npm run lint` *(fails: react hooks lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_683ccf0c7794832395260d6ae6db88b7