### PR TITLE
Fix Fabric backdrop layering

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -207,7 +207,7 @@ const handleSwap = (url: string) => {
 
   /* ---------------- UI ------------------------------------------ */
   return (
-    <div className="flex h-screen relative bg-[--walty-cream]">
+    <div className="flex h-screen relative bg-white">
 
       {/* global overlays */}
       <CoachMark
@@ -264,7 +264,7 @@ const handleSwap = (url: string) => {
         </nav>
 
         {/* canvases */}
-        <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
+        <div className="flex-1 flex justify-center items-start overflow-auto bg-white pt-6 gap-6">
           {/* front */}
           <div className={section === 'front' ? box : 'hidden'}>
             <FabricCanvas

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -291,8 +291,8 @@ const addBackdrop = (fc: fabric.Canvas) => {
   })
   ;(bg as any)._backdrop = true   // flag so we don’t add twice
 
-  bg.sendToBack()
   fc.add(bg)
+  bg.sendToBack()
 }
 
 /* ---------- component ------------------------------------------- */
@@ -982,7 +982,7 @@ img.on('mouseup', () => {
       ref={canvasRef}
       width={PREVIEW_W}
       height={PREVIEW_H}
-      className="border w-full h-auto max-w-[420px] shadow"
+      className="border w-full h-auto max-w-[420px] shadow bg-white"
     />
   )
 }


### PR DESCRIPTION
## Summary
- fix layering when adding white backdrop rectangle
- editor pages use white backgrounds

## Testing
- `npm run lint` *(fails: React hook rules errors)*

------
https://chatgpt.com/codex/tasks/task_e_683cdb74dfd88323991de8a8effe844b