### PR TITLE
Add cover image field and editor upload

### DIFF
--- a/app/admin/templates/[id]/EditorWrapper.tsx
+++ b/app/admin/templates/[id]/EditorWrapper.tsx
@@ -22,13 +22,13 @@ export default function EditorWrapper({templateId, initialPages}: Props) {
   const [error, setErr] = useState<string | null>(null)
 
   /** CardEditor → onSave */
-  const handleSave = async (pages: TemplatePage[]) => {
+  const handleSave = async (pages: TemplatePage[], coverImageId?: string) => {
     try {
       setErr(null)
       const res = await fetch(`/api/templates/${templateId}`, {
         method : 'PATCH',            // or POST – both accepted
         headers: {'content-type': 'application/json'},
-        body   : JSON.stringify({pages}),
+        body   : JSON.stringify({ pages, coverImage: coverImageId }),
       })
 
       if (!res.ok) {

--- a/app/admin/templates/[id]/page.tsx
+++ b/app/admin/templates/[id]/page.tsx
@@ -22,7 +22,7 @@ export default async function AdminTemplatePage({
   params: {id: string}
 }) {
   /* 1. fetch the *draft* template (404 if missing) */
-  const pages = await getTemplatePages(id)
+  const { pages } = await getTemplatePages(id)
   if (!pages) notFound()
 
   /* 2. load the client wrapper *only on the client* */

--- a/app/api/templates/[id]/route.ts
+++ b/app/api/templates/[id]/route.ts
@@ -33,7 +33,10 @@ export async function PATCH(
 ) {
   try {
     /* ---------- 1 ▸ validate body ----------------------------- */
-    const { pages } = (await req.json()) as { pages: any }
+    const { pages, coverImage } = (await req.json()) as {
+      pages: any
+      coverImage?: string
+    }
     if (!Array.isArray(pages) || pages.length !== 4) {
       return NextResponse.json(
         { error: '`pages` must be an array with exactly four items' },
@@ -67,6 +70,12 @@ export async function PATCH(
         p.set({
           pages: sanePages,
           json : JSON.stringify(pages), // raw mirror – round-trip safety-net
+          ...(coverImage && {
+            coverImage: {
+              _type: 'image',
+              asset: { _type: 'reference', _ref: coverImage },
+            },
+          }),
         }),
       )
       .commit({ autoGenerateArrayKeys: true })

--- a/app/cards/[slug]/customise/page.tsx
+++ b/app/cards/[slug]/customise/page.tsx
@@ -2,8 +2,8 @@
  * cards/[slug]/customise/page.tsx
  *********************************************************************/
 
-import { templates } from "@/data/templates";
 import CustomiseClient from "./CustomiseClient";
+import { getTemplatePages } from '@/app/library/getTemplatePages'
 
 // Path: app/cards/[slug]/customise/page.tsx
 // This is a **server component**. In Next 15 `params` is a Promise, so we need to
@@ -17,11 +17,8 @@ export default async function CustomisePage({
   // 🡇 open the "params" gift‑box and pull out slug
   const { slug } = await params;
 
-  const tpl = templates.find((t) => t.slug === slug);
-  if (!tpl) return <p>Template not found</p>;
+  const { pages } = await getTemplatePages(slug)
+  console.log('SERVER tpl.pages =', pages)
 
-  console.log("SERVER tpl.pages =", tpl.pages);
-  
-  /* pass the template down as a plain prop */
-  return <CustomiseClient tpl={tpl} />;
+  return <CustomiseClient tpl={{ pages }} />;
 }

--- a/app/cards/[slug]/page.tsx
+++ b/app/cards/[slug]/page.tsx
@@ -1,13 +1,15 @@
 import { templates } from "@/data/templates";
 import { notFound } from "next/navigation";
+import { getTemplatePages } from '@/app/library/getTemplatePages'
 
-export default function Product({ params }: { params: { slug: string } }) {
-  const tpl = templates.find((t) => t.slug === params.slug);
-  if (!tpl) notFound();
+export default async function Product({ params }: { params: { slug: string } }) {
+  const tpl = templates.find((t) => t.slug === params.slug)
+  if (!tpl) notFound()
+  const { coverImage } = await getTemplatePages(params.slug)
 
   return (
     <main className="p-6 flex flex-col items-center">
-      <img src={tpl.cover} alt="" className="w-64 rounded shadow" />
+      <img src={coverImage || tpl.cover} alt="" className="w-64 rounded shadow" />
       <h1 className="text-2xl font-bold mt-4">{tpl.title}</h1>
 
       <a

--- a/sanity/schemaTypes/cardTemplate.ts
+++ b/sanity/schemaTypes/cardTemplate.ts
@@ -187,6 +187,14 @@ export default defineType({
       validation: r => r.max(300),
     }),
 
+    defineField({
+      name: 'coverImage',
+      type: 'image',
+      title: 'Cover image',
+      group: 'store',
+      options: { hotspot: true },
+    }),
+
     /* category facets */
     defineField({
       name: 'occasion',


### PR DESCRIPTION
## Summary
- add `coverImage` field to `cardTemplate` schema
- update `CardEditor` to upload front canvas image
- send new cover image id from editor wrapper to API
- store `coverImage` in template API route
- return cover image URL from `getTemplatePages`
- show cover image on storefront pages

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks, no-img-element, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6842044f6d7883239c657904ea55df73