### PR TITLE
Display live cards on home page

### DIFF
--- a/app/cards/[slug]/customise/CustomiseClient.tsx
+++ b/app/cards/[slug]/customise/CustomiseClient.tsx
@@ -14,6 +14,6 @@
        (window as any).tplPages = tpl.pages;
      }
    
-     // 3️⃣ pass mode="staff" so the editor shows all controls
-     return <CardEditor initialPages={tpl.pages} mode="staff" />;
+     // 3️⃣ use customer mode so shoppers get the streamlined editor
+     return <CardEditor initialPages={tpl.pages} mode="customer" />;
    }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,13 +3,22 @@ import Image from "next/image";
 import Link from "next/link";
 import { Pencil, Truck, Star } from "lucide-react";
 import { recoleta } from "@/lib/fonts"; // ① <— brings in your local Recoleta
+import { sanityFetch } from "@/lib/sanityClient";
+import { urlFor } from "@/sanity/lib/image";
 
-export default function HomePage() {
+export default async function HomePage() {
   /* Brand palette */
   const cream  = "#F7F3EC";
   const teal   = "#005B55";
   const orange = "#C64A19";
   const brown  = "#3E2C20";
+
+  const templates = await sanityFetch<{
+    _id: string
+    title: string
+    slug: {current: string}
+    coverImage?: any
+  }[]>(`*[_type=="cardTemplate" && isLive==true]{_id,title,slug,coverImage}`)
 
   return (
     <main
@@ -83,18 +92,18 @@ export default function HomePage() {
         </h2>
 
         <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-8">
-          {[
-            "super","arch","floral","rainbow","burst",
-            "cats","thanks","landscape","grad",
-          ].map((slug) => (
-            <Image
-              key={slug}
-              src={`/images/templates/${slug}.jpg`}
-              alt={`${slug} card template`}
-              width={480}
-              height={640}
-              className="rounded-lg shadow-md hover:shadow-lg transition"
-            />
+          {templates.map((tpl) => (
+            <Link key={tpl._id} href={`/cards/${tpl.slug.current}/customise`}>
+              {tpl.coverImage && (
+                <Image
+                  src={urlFor(tpl.coverImage).width(480).height(640).url()}
+                  alt={tpl.title}
+                  width={480}
+                  height={640}
+                  className="rounded-lg shadow-md hover:shadow-lg transition"
+                />
+              )}
+            </Link>
           ))}
         </div>
       </section>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,16 @@ const nextConfig = {
     )
     return config
   },
+
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.sanity.io',
+        pathname: '/images/**',
+      },
+    ],
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- fetch live card templates from Sanity and render on the homepage
- link each cover image directly to the customer editor
- use customer mode in the customise page

## Testing
- `npm run lint` *(fails: react-hooks rules and other existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68420994cf848323a866154f4bccec74