### PR TITLE
Ensure crop scaling never shrinks image past window

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -537,8 +537,8 @@ export class CropTool {
         this.fc.requestRenderAll();
       })
       .on('scaling', () => {
-        // continuously refresh coords so the next render picks up the
-        // changing size—prevents stale handles after multiple enlarges.
+        // continuously clamp so the photo can't shrink inside the window
+        this.clamp(true);             // force clamp during interactive scale
         this.img!.setCoords();
         updateMasks();
         this.frameScaling = true;    // ON while photo itself is scaling
@@ -580,8 +580,8 @@ export class CropTool {
   }
 
   /* keep bitmap inside frame */
-  private clamp = () => {
-    if (this.frameScaling) return;
+  private clamp = (force = false) => {
+    if (!force && this.frameScaling) return;
     if (!this.img || !this.frame) return
     const { img, frame } = this
     const minSX = frame.width!*frame.scaleX! / img.width!


### PR DESCRIPTION
## Summary
- prevent image scaling from going smaller than the crop frame in `CropTool`
- allow clamp helper to bypass scaling lock when needed

## Testing
- `npm run lint` *(fails: React hook rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68460b947878832389194e9b64334d63