### PR TITLE
Fix crop tool image lock

### DIFF
--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -718,6 +718,10 @@ export class CropTool {
     if (!keep) this.fc.discardActiveObject()
     this.fc.requestRenderAll()
 
+    if (this.img) {
+      this.img.lockMovementX = false
+      this.img.lockMovementY = false
+    }
     this.frame    = null
     this.img      = null
     this.orig     = null

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -658,6 +658,16 @@ export class CropTool {
         updateMasks();
         this.fc.requestRenderAll();
       });
+
+    // remove object event listeners when crop ends
+    this.cleanup.push(() => {
+      this.frame?.off('moving');
+      this.frame?.off('scaling');
+      this.frame?.off('scaled');
+      img.off('moving');
+      img.off('scaling');
+      img.off('scaled');
+    });
   }
 
   public cancel () {


### PR DESCRIPTION
## Summary
- ensure CropTool unlocks image movement after cropping concludes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails with React hook rule errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849dec989248323a57f807134032f6f