### PR TITLE
Add header roof to CardEditor

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -280,148 +280,144 @@ const handleSwap = (url: string) => {
 
   /* ---------------- UI ------------------------------------------ */
   return (
-    <div className="flex h-screen relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
+    <div className="flex flex-col h-screen">
+      <header className="h-14 bg-walty-teal flex-shrink-0" />
+      <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
+        {/* global overlays */}
+        <CoachMark
+          anchor={anchor}
+          onClose={() => {
+            setAnchor(null)
+            localStorage.setItem('ai_coachmark_shown', '1')
+          }}
+        />
+        <SelfieDrawer
+          open={drawerOpen}
+          onClose={() => setDrawerOpen(false)}
+          onUseSelected={handleSwap}
+          placeholderId={aiPlaceholderId}   /* ← NEW prop */
+        />
 
-      {/* global overlays */}
-      <CoachMark
-        anchor={anchor}
-        onClose={() => {
-          setAnchor(null)
-          localStorage.setItem('ai_coachmark_shown', '1')
-        }}
-      />
-      <SelfieDrawer
-        open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        onUseSelected={handleSwap}
-        placeholderId={aiPlaceholderId}   /* ← NEW prop */
-      />
+        <EditorCommands
+          onUndo={undo}
+          onRedo={redo}
+          onSave={handleSave}
+          saving={saving}
+        />
 
-      <EditorCommands
-        onUndo={undo}
-        onRedo={redo}
-        onSave={handleSave}
-        saving={saving}
-      />
-
-{/* sidebar */}
-<div className="relative z-30 w-64 flex-shrink-0">
-  <LayerPanel />
-</div>
-
-      {/* main */}
-      <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[840px] -translate-x-24 lg:-translate-x-28 xl:-translate-x-32">
-     {activeType === 'text' && (
-       <TextToolbar
-         canvas={activeFc}
-         addText={addText}
-         addImage={addImage}
-         mode={mode}
-         saving={saving}
-       />
-     )}
-     {activeType === 'image' && (
-       <ImageToolbar
-         canvas={activeFc}
-         saving={saving}
-       />
-     )}
-
-        {/* tabs */}
-        <nav className="flex justify-center gap-8 py-3 text-sm font-medium">
-          {(['front','inside','back'] as Section[]).map(lbl => (
-            <button
-              key={lbl}
-              onClick={() => setSection(lbl)}
-              className={
-                section === lbl
-                  ? 'text-blue-600 border-b-2 border-blue-600 pb-1'
-                  : 'text-gray-500 hover:text-gray-800'
-              }
-            >
-              {lbl.replace(/^./, c => c.toUpperCase())}
-            </button>
-          ))}
-        </nav>
-
-        {/* canvases */}
-        <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
-          {/* front */}
-          <div className={section === 'front' ? box : 'hidden'}>
-            <FabricCanvas
-              pageIdx={0}
-              page={pages[0]}
-              onReady={fc => onReady(0, fc)}
-              isCropping={cropping[0]}
-              onCroppingChange={state => handleCroppingChange(0, state)}
-            />
-          </div>
-          {/* inside */}
-          <div className={section === 'inside' ? 'flex gap-6' : 'hidden'}>
-            <div className={box}>
-              <FabricCanvas
-                pageIdx={1}
-                page={pages[1]}
-                onReady={fc => onReady(1, fc)}
-                isCropping={cropping[1]}
-                onCroppingChange={state => handleCroppingChange(1, state)}
-              />
-            </div>
-            <div className={box}>
-              <FabricCanvas
-                pageIdx={2}
-                page={pages[2]}
-                onReady={fc => onReady(2, fc)}
-                isCropping={cropping[2]}
-                onCroppingChange={state => handleCroppingChange(2, state)}
-              />
-            </div>
-          </div>
-          {/* back */}
-          <div className={section === 'back' ? box : 'hidden'}>
-            <FabricCanvas
-              pageIdx={3}
-              page={pages[3]}
-              onReady={fc => onReady(3, fc)}
-              isCropping={cropping[3]}
-              onCroppingChange={state => handleCroppingChange(3, state)}
-            />
-          </div>
+        {/* sidebar */}
+        <div className="relative z-30 w-64 flex-shrink-0">
+          <LayerPanel />
         </div>
 
-        {/* thumbnails */}
-        <div className="
-   thumbnail-bar sticky bottom-0 z-20
-   flex justify-center gap-2
-    px-3 py-2
-    bg-[--walty-cream]       /* opaque backdrop so canvases don’t show through */
-    text-xs
-  ">
-          {(['FRONT', 'INNER-L', 'INNER-R', 'BACK'] as const).map((lbl, i) => (
-            <button
-              key={lbl}
-              className={`thumb ${
-                (section === 'front'  && i === 0) ||
-                (section === 'inside' && (i === 1 || i === 2)) ||
-                (section === 'back'   && i === 3)
-                  ? 'thumb-active'
-                  : ''
-              }`}
-              onClick={() =>
-                setSection(i === 0 ? 'front' : i === 3 ? 'back' : 'inside')
-              }
-            >
-              {thumbs[i] ? (
-                <img
-                  src={thumbs[i]}
-                  alt={lbl}
-                  className="h-full w-full object-cover"
+        {/* main */}
+        <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[840px] -translate-x-24 lg:-translate-x-28 xl:-translate-x-32">
+          {activeType === 'text' && (
+            <TextToolbar
+              canvas={activeFc}
+              addText={addText}
+              addImage={addImage}
+              mode={mode}
+              saving={saving}
+            />
+          )}
+          {activeType === 'image' && (
+            <ImageToolbar
+              canvas={activeFc}
+              saving={saving}
+            />
+          )}
+
+          {/* tabs */}
+          <nav className="flex justify-center gap-8 py-3 text-sm font-medium">
+            {(['front', 'inside', 'back'] as Section[]).map(lbl => (
+              <button
+                key={lbl}
+                onClick={() => setSection(lbl)}
+                className={
+                  section === lbl
+                    ? 'text-blue-600 border-b-2 border-blue-600 pb-1'
+                    : 'text-gray-500 hover:text-gray-800'
+                }
+              >
+                {lbl.replace(/^./, c => c.toUpperCase())}
+              </button>
+            ))}
+          </nav>
+
+          {/* canvases */}
+          <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
+            {/* front */}
+            <div className={section === 'front' ? box : 'hidden'}>
+              <FabricCanvas
+                pageIdx={0}
+                page={pages[0]}
+                onReady={fc => onReady(0, fc)}
+                isCropping={cropping[0]}
+                onCroppingChange={state => handleCroppingChange(0, state)}
+              />
+            </div>
+            {/* inside */}
+            <div className={section === 'inside' ? 'flex gap-6' : 'hidden'}>
+              <div className={box}>
+                <FabricCanvas
+                  pageIdx={1}
+                  page={pages[1]}
+                  onReady={fc => onReady(1, fc)}
+                  isCropping={cropping[1]}
+                  onCroppingChange={state => handleCroppingChange(1, state)}
                 />
-              ) : (
-                lbl
-              )}
-            </button>
-          ))}
+              </div>
+              <div className={box}>
+                <FabricCanvas
+                  pageIdx={2}
+                  page={pages[2]}
+                  onReady={fc => onReady(2, fc)}
+                  isCropping={cropping[2]}
+                  onCroppingChange={state => handleCroppingChange(2, state)}
+                />
+              </div>
+            </div>
+            {/* back */}
+            <div className={section === 'back' ? box : 'hidden'}>
+              <FabricCanvas
+                pageIdx={3}
+                page={pages[3]}
+                onReady={fc => onReady(3, fc)}
+                isCropping={cropping[3]}
+                onCroppingChange={state => handleCroppingChange(3, state)}
+              />
+            </div>
+          </div>
+
+          {/* thumbnails */}
+          <div className="thumbnail-bar sticky bottom-0 z-20 flex justify-center gap-2 px-3 py-2 bg-[--walty-cream] text-xs">
+            {(['FRONT', 'INNER-L', 'INNER-R', 'BACK'] as const).map((lbl, i) => (
+              <button
+                key={lbl}
+                className={`thumb ${
+                  (section === 'front' && i === 0) ||
+                  (section === 'inside' && (i === 1 || i === 2)) ||
+                  (section === 'back' && i === 3)
+                    ? 'thumb-active'
+                    : ''
+                }`}
+                onClick={() =>
+                  setSection(i === 0 ? 'front' : i === 3 ? 'back' : 'inside')
+                }
+              >
+                {thumbs[i] ? (
+                  <img
+                    src={thumbs[i]}
+                    alt={lbl}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  lbl
+                )}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -1,10 +1,3 @@
-/**********************************************************************
- * CardEditor.tsx  –  WYSIWYG editor for a 4-page greeting card
- * --------------------------------------------------------------------
- * ▸ Staff mode     – toolbar shows upload / font tools
- * ▸ Customer mode  – stripped-down toolbar
- * 2025-05-11       – wires SelfieDrawer → swaps chosen variant into canvas
- *********************************************************************/
 'use client'
 
 import { useEffect, useRef, useState, useLayoutEffect } from 'react'
@@ -282,6 +275,14 @@ const handleSwap = (url: string) => {
   return (
     <div className="flex flex-col h-screen">
       <header className="h-14 bg-walty-teal flex-shrink-0" />
+
+      <EditorCommands
+        onUndo={undo}
+        onRedo={redo}
+        onSave={handleSave}
+        saving={saving}
+      />
+
       <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
         {/* global overlays */}
         <CoachMark
@@ -298,12 +299,6 @@ const handleSwap = (url: string) => {
           placeholderId={aiPlaceholderId}   /* ← NEW prop */
         />
 
-        <EditorCommands
-          onUndo={undo}
-          onRedo={redo}
-          onSave={handleSave}
-          saving={saving}
-        />
 
         {/* sidebar */}
         <div className="relative z-30 w-64 flex-shrink-0">
@@ -328,24 +323,7 @@ const handleSwap = (url: string) => {
             />
           )}
 
-          {/* tabs */}
-          <nav className="flex justify-center gap-8 py-3 text-sm font-medium">
-            {(['front', 'inside', 'back'] as Section[]).map(lbl => (
-              <button
-                key={lbl}
-                onClick={() => setSection(lbl)}
-                className={
-                  section === lbl
-                    ? 'text-blue-600 border-b-2 border-blue-600 pb-1'
-                    : 'text-gray-500 hover:text-gray-800'
-                }
-              >
-                {lbl.replace(/^./, c => c.toUpperCase())}
-              </button>
-            ))}
-          </nav>
-
-          {/* canvases */}
+                    {/* canvases */}
           <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
             {/* front */}
             <div className={section === 'front' ? box : 'hidden'}>

--- a/app/components/EditorCommands.tsx
+++ b/app/components/EditorCommands.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export default function EditorCommands({ onUndo, onRedo, onSave, saving }: Props) {
   return (
-    <div className="fixed right-4 top-2 z-40 flex gap-3 pointer-events-auto select-none bg-white shadow rounded-md px-3 py-2">
+    <div className="sticky top-2 ml-auto mr-4 z-40 flex gap-3 pointer-events-auto select-none bg-white shadow rounded-md px-3 py-2">
       <IconButton Icon={RotateCcw} label="Undo" onClick={onUndo} />
       <IconButton Icon={RotateCw} label="Redo" onClick={onRedo} />
       <button

--- a/app/components/EditorCommands.tsx
+++ b/app/components/EditorCommands.tsx
@@ -13,7 +13,8 @@ interface Props {
 
 export default function EditorCommands({ onUndo, onRedo, onSave, saving }: Props) {
   return (
-    <div className="sticky top-2 ml-auto mr-4 order-last self-start z-40 flex gap-3 pointer-events-auto select-none bg-white shadow rounded-md px-3 py-2">
+    <div className="fixed top-14   right-6 z-40 flex items-center gap-3
+                     bg-white shadow rounded-md px-3 py-3 pointer-events-auto select-none">
       <IconButton Icon={RotateCcw} label="Undo" onClick={onUndo} />
       <IconButton Icon={RotateCw} label="Redo" onClick={onRedo} />
       <button

--- a/app/components/EditorCommands.tsx
+++ b/app/components/EditorCommands.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export default function EditorCommands({ onUndo, onRedo, onSave, saving }: Props) {
   return (
-    <div className="sticky top-2 ml-auto mr-4 z-40 flex gap-3 pointer-events-auto select-none bg-white shadow rounded-md px-3 py-2">
+    <div className="sticky top-2 ml-auto mr-4 order-last self-start z-40 flex gap-3 pointer-events-auto select-none bg-white shadow rounded-md px-3 py-2">
       <IconButton Icon={RotateCcw} label="Undo" onClick={onUndo} />
       <IconButton Icon={RotateCw} label="Redo" onClick={onRedo} />
       <button

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -134,7 +134,7 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
 
   /* ───────────────────────── render ─── */
   return (
-    <div className="fixed inset-x-0 top-2 z-30 flex justify-center pointer-events-none select-none">
+    <div className="sticky inset-x-0 top-2 z-30 flex justify-center pointer-events-none select-none">
       {/* main bar */}
       <div
         className="pointer-events-auto flex flex-nowrap items-center gap-6

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -110,7 +110,7 @@ export default function LayerPanel() {
   };
     return (
         <aside
-        className={`fixed left-0 top-0 z-20 h-full
+        className={`fixed left-0 top-14 z-20 h-[calc(100%-56px)]
                       w-54 sm:w-60 md:w-64 lg:w-70 xl:w-74
                       rounded-r-2xl bg-white shadow-xl ring-2 ring-walty-teal/40
                       transition-transform duration-300

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -158,10 +158,10 @@ export default function TextToolbar (props: Props) {
       {mode === 'staff' && (
         <div
           className="
-            pointer-events-auto flex flex-nowrap items-center gap-4
+            pointer-events-auto flex flex-nowrap items-center gap-3
             bg-white shadow-lg rounded-xl
-            border border-[rgba(0,91,85,.2)] px-4 py-2
-            max-w-none w-[calc(100%-2rem)]]"
+            border border-[rgba(0,91,85,.2)] px-4 py-3
+            max-w-none w-[calc(100%-rem)]"
         >
           {/* ───────── Font family & size (no captions) ───────── */}
           <FontFamilySelect

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -153,7 +153,7 @@ export default function TextToolbar (props: Props) {
   /* 7.  Render                                                         */
   /* ------------------------------------------------------------------ */
   return (
-    <div className="fixed inset-x-0 top-2 z-30 flex justify-center pointer-events-none select-none">
+    <div className="sticky inset-x-0 top-2 z-30 flex justify-center pointer-events-none select-none">
 
       {mode === 'staff' && (
         <div


### PR DESCRIPTION
## Summary
- add a fixed-height header for the card editor page
- shift editor layout into a flex column
- change sidebar and command/toolbars to respect the new header

## Testing
- `npm run lint` *(fails: React hooks warnings and other pre-existing issues)*
- `npx tsc -p tsconfig.json` *(fails: missing modules and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a0c26ad548323a88bf4d5e79755e9