### PR TITLE
Fix editor header overlap

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -277,7 +277,7 @@ const handleSwap = (url: string) => {
   return (
     <div
       className="flex flex-col h-screen box-border"
-      style={{ paddingTop: "var(--walty-header-h)" }}
+      style={{ paddingTop: "calc(var(--walty-header-h) + var(--walty-toolbar-h))" }}
     >
       <WaltyEditorHeader                     /* ② mount new component */
         onPreview={() => console.log("preview")}

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -275,7 +275,10 @@ const handleSwap = (url: string) => {
 
   /* ---------------- UI ------------------------------------------ */
   return (
-    <div className="flex flex-col h-screen">
+    <div
+      className="flex flex-col h-screen box-border"
+      style={{ paddingTop: "var(--walty-header-h)" }}
+    >
       <WaltyEditorHeader                     /* ② mount new component */
         onPreview={() => console.log("preview")}
         onAddToBasket={() => console.log("basket")}

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -136,7 +136,10 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
   return (
     <div
       className="sticky inset-x-0 z-30 flex justify-center pointer-events-none select-none"
-      style={{ top: "var(--walty-header-h)" }}
+      style={{
+        top: "var(--walty-header-h)",
+        marginTop: "calc(var(--walty-toolbar-h) * -1)",
+      }}
     >
       {/* main bar */}
       <div

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -134,7 +134,10 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
 
   /* ───────────────────────── render ─── */
   return (
-    <div className="sticky inset-x-0 top-2 z-30 flex justify-center pointer-events-none select-none">
+    <div
+      className="sticky inset-x-0 z-30 flex justify-center pointer-events-none select-none"
+      style={{ top: "calc(var(--walty-header-h) + 0.5rem)" }}
+    >
       {/* main bar */}
       <div
         className="pointer-events-auto flex flex-nowrap items-center gap-6

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -136,7 +136,7 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
   return (
     <div
       className="sticky inset-x-0 z-30 flex justify-center pointer-events-none select-none"
-      style={{ top: "calc(var(--walty-header-h) + 0.5rem)" }}
+      style={{ top: "var(--walty-header-h)" }}
     >
       {/* main bar */}
       <div

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -108,13 +108,15 @@ export default function LayerPanel() {
     if (e.over && e.active.id !== e.over.id)
       reorder(+e.active.id, +e.over.id);
   };
-    return (
+
+  return (
         <aside
-        className={`fixed left-0 top-14 z-20 h-[calc(100%-56px)]
+        className={`fixed left-0 z-20
                       w-54 sm:w-60 md:w-64 lg:w-70 xl:w-74
                       rounded-r-2xl bg-white shadow-xl ring-2 ring-walty-teal/40
                       transition-transform duration-300
                       ${open ? "translate-x-0" : "-translate-x-full"}`}
+        style={{ top: "var(--walty-header-h)", height: "calc(100vh - var(--walty-header-h))" }}
         >
 
 

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -153,7 +153,10 @@ export default function TextToolbar (props: Props) {
   /* 7.  Render                                                         */
   /* ------------------------------------------------------------------ */
   return (
-    <div className="sticky inset-x-0 top-2 z-30 flex justify-center pointer-events-none select-none">
+    <div
+      className="sticky inset-x-0 z-30 flex justify-center pointer-events-none select-none"
+      style={{ top: "calc(var(--walty-header-h) + 0.5rem)" }}
+    >
 
       {mode === 'staff' && (
         <div

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -155,7 +155,10 @@ export default function TextToolbar (props: Props) {
   return (
     <div
       className="sticky inset-x-0 z-30 flex justify-center pointer-events-none select-none"
-      style={{ top: "var(--walty-header-h)" }}
+      style={{
+        top: "var(--walty-header-h)",
+        marginTop: "calc(var(--walty-toolbar-h) * -1)",
+      }}
     >
 
       {mode === 'staff' && (

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -155,7 +155,7 @@ export default function TextToolbar (props: Props) {
   return (
     <div
       className="sticky inset-x-0 z-30 flex justify-center pointer-events-none select-none"
-      style={{ top: "calc(var(--walty-header-h) + 0.5rem)" }}
+      style={{ top: "var(--walty-header-h)" }}
     >
 
       {mode === 'staff' && (

--- a/app/components/WaltyEditorHeader.tsx
+++ b/app/components/WaltyEditorHeader.tsx
@@ -25,8 +25,14 @@ export default function WaltyEditorHeader({
         "--walty-header-h",
         `${height}px`
       );
-      return () =>
+      document.documentElement.style.setProperty(
+        "--walty-toolbar-h",
+        "72px"
+      );
+      return () => {
         document.documentElement.style.removeProperty("--walty-header-h");
+        document.documentElement.style.removeProperty("--walty-toolbar-h");
+      };
     }
   }, [height]);
   return (
@@ -37,6 +43,7 @@ export default function WaltyEditorHeader({
         // toolbars read this for their `top` value
         // (TextToolbar, ImageToolbar, EditorCommands wrappers)
         "--walty-header-h": `${height}px`,
+        "--walty-toolbar-h": "72px",
       } as React.CSSProperties}
     >
       <div className="mx-auto flex h-full max-w-6xl items-center justify-between px-6">

--- a/app/components/WaltyEditorHeader.tsx
+++ b/app/components/WaltyEditorHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { useEffect } from "react";
 
 /**
  * Walty branded editor header.
@@ -18,6 +19,16 @@ export default function WaltyEditorHeader({
   onAddToBasket: () => void | Promise<void>;
   height?: number;
 }) {
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.documentElement.style.setProperty(
+        "--walty-header-h",
+        `${height}px`
+      );
+      return () =>
+        document.documentElement.style.removeProperty("--walty-header-h");
+    }
+  }, [height]);
   return (
     <header
       className="fixed inset-x-0 top-0 z-50 bg-[--walty-teal]"


### PR DESCRIPTION
## Summary
- inject `--walty-header-h` globally so other components can read it
- push editor content below the fixed header
- offset toolbars and side panel with the header height

## Testing
- `npm run lint` *(fails: React Hook lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a9e2792a88323ac6abdeddf864eb2