### PR TITLE
Fix toolbar shift

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -316,7 +316,7 @@ const handleSwap = (url: string) => {
 
         {/* main */}
         <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[840px] -translate-x-24 lg:-translate-x-28 xl:-translate-x-32">
-          {activeType === 'text' && (
+          {activeType === 'text' ? (
             <TextToolbar
               canvas={activeFc}
               addText={addText}
@@ -324,11 +324,19 @@ const handleSwap = (url: string) => {
               mode={mode}
               saving={saving}
             />
-          )}
-          {activeType === 'image' && (
+          ) : activeType === 'image' ? (
             <ImageToolbar
               canvas={activeFc}
               saving={saving}
+            />
+          ) : (
+            <div
+              className="sticky inset-x-0 z-30 flex justify-center pointer-events-none select-none"
+              style={{
+                top: 'var(--walty-header-h)',
+                marginTop: 'calc(var(--walty-toolbar-h) * -1)',
+                height: 'var(--walty-toolbar-h)',
+              }}
             />
           )}
 

--- a/app/components/ImageToolbar.tsx
+++ b/app/components/ImageToolbar.tsx
@@ -139,6 +139,7 @@ export default function ImageToolbar({ canvas: fc, saving }: Props) {
       style={{
         top: "var(--walty-header-h)",
         marginTop: "calc(var(--walty-toolbar-h) * -1)",
+        height: "var(--walty-toolbar-h)",
       }}
     >
       {/* main bar */}

--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -158,6 +158,7 @@ export default function TextToolbar (props: Props) {
       style={{
         top: "var(--walty-header-h)",
         marginTop: "calc(var(--walty-toolbar-h) * -1)",
+        height: "var(--walty-toolbar-h)",
       }}
     >
 


### PR DESCRIPTION
## Summary
- keep toolbar slot height constant so canvas doesn't shift
- set toolbar wrappers to fixed height

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684aa99983b88323896631159a5f8797