### PR TITLE
Center editor canvas

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -292,7 +292,10 @@ const handleSwap = (url: string) => {
         saving={saving}
       />
 
-      <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
+      <div
+        className="flex flex-1 relative bg-[--walty-cream]"
+        style={{ marginLeft: '16rem', width: 'calc(100% - 16rem)' }}
+      >
         {/* global overlays */}
         <CoachMark
           anchor={anchor}

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -292,10 +292,7 @@ const handleSwap = (url: string) => {
         saving={saving}
       />
 
-      <div
-        className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto"
-        style={{ transform: 'translateX(-8rem)' }}
-      >
+      <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
         {/* global overlays */}
         <CoachMark
           anchor={anchor}
@@ -318,7 +315,10 @@ const handleSwap = (url: string) => {
         </div>
 
         {/* main */}
-        <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[840px]">
+        <div
+          className="flex flex-col flex-1 min-h-0 mx-auto max-w-[840px]"
+          style={{ transform: 'translateX(-8rem)' }}
+        >
           {activeType === 'text' ? (
             <TextToolbar
               canvas={activeFc}

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -293,8 +293,8 @@ const handleSwap = (url: string) => {
       />
 
       <div
-        className="flex flex-1 relative bg-[--walty-cream]"
-        style={{ marginLeft: '16rem', width: 'calc(100% - 16rem)' }}
+        className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto"
+        style={{ transform: 'translateX(-8rem)' }}
       >
         {/* global overlays */}
         <CoachMark


### PR DESCRIPTION
## Summary
- center the editor canvas, toolbars and thumbnails

## Testing
- `npm run lint` *(fails: React hooks errors, next/image warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684ab58bcc5c8323b7b3e015202374cd