### PR TITLE
Add product mockup schema and preview modal

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -12,6 +12,7 @@ import TextToolbar                      from './TextToolbar'
 import ImageToolbar                     from './ImageToolbar'
 import EditorCommands                   from './EditorCommands'
 import SelfieDrawer                     from './SelfieDrawer'
+import PreviewModal                    from './PreviewModal'
 import { CropTool }                     from '@/lib/CropTool'
 import WaltyEditorHeader                from './WaltyEditorHeader'
 import type { TemplatePage }            from './FabricCanvas'
@@ -52,8 +53,8 @@ function CoachMark({ anchor, onClose }: { anchor: DOMRect | null; onClose: () =>
         </button>
         <div className="absolute -left-2 top-6 w-0 h-0 border-y-8 border-y-transparent border-r-[12px] border-r-gray-800" />
       </div>
-    </div>
-  )
+  </div>
+ )
 }
 
 /* ────────────────────────────────────────────────────────────────── */
@@ -207,6 +208,10 @@ export default function CardEditor({
 const [drawerOpen, setDrawerOpen]           = useState(false)
 const [aiPlaceholderId, setAiPlaceholderId] = useState<string | null>(null)
 
+/* preview modal state */
+const [previewOpen, setPreviewOpen] = useState(false)
+const [previewImgs, setPreviewImgs] = useState<string[]>([])
+
 /* listen for the event FabricCanvas now emits */
 useEffect(() => {
   const open = (e: Event) => {
@@ -237,6 +242,20 @@ const handleSwap = (url: string) => {
   })
 
   setDrawerOpen(false)
+}
+
+/* generate images and show preview */
+const handlePreview = () => {
+  const imgs: string[] = []
+  canvasMap.forEach((fc, i) => {
+    if (!fc) return
+    const tool = (fc as any)._cropTool as CropTool | undefined
+    if (tool?.isActive) tool.commit()
+    fc.renderAll()
+    imgs[i] = fc.toDataURL({ format: 'png', quality: 1 })
+  })
+  setPreviewImgs(imgs)
+  setPreviewOpen(true)
 }
 
   /* 7 ─ coach-mark ----------------------------------------------- */
@@ -280,7 +299,7 @@ const handleSwap = (url: string) => {
       style={{ paddingTop: "calc(var(--walty-header-h) + var(--walty-toolbar-h))" }}
     >
       <WaltyEditorHeader                     /* ② mount new component */
-        onPreview={() => console.log("preview")}
+        onPreview={handlePreview}
         onAddToBasket={() => console.log("basket")}
         height={72}                          /* match the design */
       />
@@ -413,6 +432,11 @@ const handleSwap = (url: string) => {
           </div>
         </div>
       </div>
+      <PreviewModal
+        open={previewOpen}
+        images={previewImgs}
+        onClose={() => setPreviewOpen(false)}
+      />
     </div>
   )
 }

--- a/app/components/PreviewModal.tsx
+++ b/app/components/PreviewModal.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { Dialog, Transition } from '@headlessui/react'
+import { Fragment, useEffect, useRef, useState } from 'react'
+
+export interface PreviewModalProps {
+  open: boolean
+  images: string[]
+  onClose: () => void
+}
+
+export default function PreviewModal({ open, images, onClose }: PreviewModalProps) {
+  const [idx, setIdx] = useState(0)
+  const startX = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (open) setIdx(0)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    images.forEach(src => { const i = new window.Image(); i.src = src })
+    const key = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') setIdx(i => (i + 1) % images.length)
+      if (e.key === 'ArrowLeft')  setIdx(i => (i - 1 + images.length) % images.length)
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', key)
+    return () => window.removeEventListener('keydown', key)
+  }, [open, images.length, onClose, images])
+
+  const touchStart = (e: React.TouchEvent) => { startX.current = e.touches[0].clientX }
+  const touchEnd = (e: React.TouchEvent) => {
+    if (startX.current === null) return
+    const dx = e.changedTouches[0].clientX - startX.current
+    const thresh = 30
+    if (dx > thresh) setIdx(i => (i - 1 + images.length) % images.length)
+    if (dx < -thresh) setIdx(i => (i + 1) % images.length)
+    startX.current = null
+  }
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="fixed inset-0 z-50 flex items-center justify-center" onClose={onClose}>
+        <div className="fixed inset-0 bg-black/60" aria-hidden="true" />
+        <Transition.Child as={Fragment} enter="ease-out duration-200" enterFrom="opacity-0 scale-95" enterTo="opacity-100 scale-100" leave="ease-in duration-150" leaveFrom="opacity-100 scale-100" leaveTo="opacity-0 scale-95">
+          <div className="relative bg-white rounded shadow-lg overflow-hidden w-[min(90vw,420px)]" onTouchStart={touchStart} onTouchEnd={touchEnd}>
+            <img src={images[idx]} alt={`page ${idx+1}`} className="w-full aspect-[3/4] object-contain" />
+            {images.length > 1 && (
+              <>
+                <button onClick={() => setIdx(i => (i - 1 + images.length) % images.length)} className="absolute left-2 top-1/2 -translate-y-1/2 text-white bg-black/40 rounded-full p-1">‹</button>
+                <button onClick={() => setIdx(i => (i + 1) % images.length)} className="absolute right-2 top-1/2 -translate-y-1/2 text-white bg-black/40 rounded-full p-1">›</button>
+              </>
+            )}
+            <button onClick={onClose} className="absolute top-2 right-2 text-white bg-black/50 rounded-full px-2">×</button>
+          </div>
+        </Transition.Child>
+      </Dialog>
+    </Transition.Root>
+  )
+}

--- a/sanity/schemaTypes/cardProduct.ts
+++ b/sanity/schemaTypes/cardProduct.ts
@@ -27,6 +27,14 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
 
+    /* which mockup images define the preview */
+    defineField({
+      name : 'mockup',
+      type : 'reference',
+      title: 'Preview mockup',
+      to   : [{type: 'productMockup'}],
+    }),
+
     /* commercial bits */
     defineField({
       name : 'price',

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -2,44 +2,46 @@
    – central export for all document / object types
    -------------------------------------------------------------- */
 
-   import cardTemplate  from './cardTemplate'
-   import cardProduct   from './cardProduct'
-   import page          from './page'
-   
-   /* AI-related ---------------------------------------------------- */
-   import aiPlaceholder from './aiPlaceholder'
-   import aiLayer       from './aiLayer'
-   
-   /* core editable objects ---------------------------------------- */
-   import editableImage from './editableImage'
-   import editableText  from './editableText'
-   import heroSection   from './heroSection'
-   
-   /* facet look-ups ----------------------------------------------- */
-   import occasion from './occasion'   // ← RE-ADDED ✔
-   import audience from './audience'   // ← RE-ADDED ✔
-   import theme    from './theme'      // ← RE-ADDED ✔
-   import relation from './relation'   // ← RE-ADDED ✔
-   
-   /* one flat array that Studio expects --------------------------- */
-   export const schemaTypes = [
-     /* documents */
-    cardTemplate,
-    cardProduct,
-    page,
-    aiPlaceholder,
-   
-     /* objects */
-    aiLayer,
-    editableImage,
-    editableText,
-    heroSection,
-   
-     /* facets */
-     occasion,
-     audience,
-     theme,
-     relation,
-   ]
-   
-   export default schemaTypes
+import cardTemplate  from './cardTemplate'
+import cardProduct   from './cardProduct'
+import productMockup from './productMockup'
+import page          from './page'
+
+/* AI-related ---------------------------------------------------- */
+import aiPlaceholder from './aiPlaceholder'
+import aiLayer       from './aiLayer'
+
+/* core editable objects ---------------------------------------- */
+import editableImage from './editableImage'
+import editableText  from './editableText'
+import heroSection   from './heroSection'
+
+/* facet look-ups ----------------------------------------------- */
+import occasion from './occasion'   // ← RE-ADDED ✔
+import audience from './audience'   // ← RE-ADDED ✔
+import theme    from './theme'      // ← RE-ADDED ✔
+import relation from './relation'   // ← RE-ADDED ✔
+
+/* one flat array that Studio expects --------------------------- */
+export const schemaTypes = [
+  /* documents */
+  cardTemplate,
+  cardProduct,
+  productMockup,
+  page,
+  aiPlaceholder,
+
+  /* objects */
+  aiLayer,
+  editableImage,
+  editableText,
+  heroSection,
+
+  /* facets */
+  occasion,
+  audience,
+  theme,
+  relation,
+]
+
+export default schemaTypes

--- a/sanity/schemaTypes/productMockup.ts
+++ b/sanity/schemaTypes/productMockup.ts
@@ -1,0 +1,38 @@
+import {defineType, defineField, defineArrayMember} from 'sanity'
+
+export default defineType({
+  name: 'productMockup',
+  type: 'document',
+  title: 'Product mockup',
+  fields: [
+    defineField({
+      name: 'title',
+      type: 'string',
+      title: 'Product name',
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'slug',
+      type: 'slug',
+      title: 'Slug',
+      options: { source: 'title', maxLength: 96 },
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'areas',
+      type: 'array',
+      title: 'Printable areas',
+      of: [
+        defineArrayMember({
+          type: 'object',
+          name: 'area',
+          fields: [
+            defineField({ name: 'name', type: 'string', validation: r => r.required() }),
+            defineField({ name: 'image', type: 'image', title: 'Preview image', validation: r => r.required() }),
+          ],
+        })
+      ],
+      validation: r => r.min(1),
+    }),
+  ],
+})


### PR DESCRIPTION
## Summary
- define `productMockup` Sanity doc for preview assets
- link card products to a mockup document
- export new schema type in Sanity index
- implement client‑side preview carousel
- hook Preview button to show the modal

## Testing
- `npm run lint` *(fails: React Hooks misuse in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_684ae30f72a0832392d998c556a4a9c0