### PR TITLE
Add relative layer geometry

### DIFF
--- a/app/components/EditorStore.ts
+++ b/app/components/EditorStore.ts
@@ -5,6 +5,15 @@
 import { create } from 'zustand'
 import type { Layer, TemplatePage } from './FabricCanvas'
 
+/* ---------- shared page constants (matches FabricCanvas) --------- */
+const DPI       = 300
+const mm        = (n: number) => (n / 25.4) * DPI
+const TRIM_W_MM = 150
+const TRIM_H_MM = 214
+const BLEED_MM  = 3
+const PAGE_W    = Math.round(mm(TRIM_W_MM + BLEED_MM * 2))
+const PAGE_H    = Math.round(mm(TRIM_H_MM + BLEED_MM * 2))
+
 /* ---------- helpers ------------------------------------------------ */
 const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v))
 
@@ -140,6 +149,10 @@ export const useEditor = create<EditorState>((set, get) => ({
       x    : 100,
       y    : 100,
       width: 200,
+      leftPct:   (100 / PAGE_W) * 100,
+      topPct:    (100 / PAGE_H) * 100,
+      widthPct:  (200 / PAGE_W) * 100,
+      heightPct: (0 / PAGE_H) * 100,
     })
 
     set({ pages: nextPages })
@@ -163,6 +176,10 @@ export const useEditor = create<EditorState>((set, get) => ({
       x        : 100,
       y        : 100,
       width    : 300,
+      leftPct:   (100 / PAGE_W) * 100,
+      topPct:    (100 / PAGE_H) * 100,
+      widthPct:  (300 / PAGE_W) * 100,
+      heightPct: (300 / PAGE_H) * 100,
       srcUrl   : blobUrl,
       uploading: true,
     } as EditorLayer)

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -691,6 +691,14 @@ window.addEventListener('keydown', onKey)
       const ly: Layer | null = (raw as any).type ? raw as Layer : fromSanity(raw)
       if (!ly) continue
 
+      const fcW = fc.getWidth()
+      const fcH = fc.getHeight()
+
+      if (ly.leftPct != null) ly.x = (ly.leftPct / 100) * fcW
+      if (ly.topPct  != null) ly.y = (ly.topPct  / 100) * fcH
+      if (ly.widthPct  != null) ly.width  = (ly.widthPct  / 100) * fcW
+      if (ly.heightPct != null) ly.height = (ly.heightPct / 100) * fcH
+
 /* ---------- IMAGES --------------------------------------------- */
 if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
   // ① make sure we have a usable URL

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -187,6 +187,9 @@ const objToLayer = (o: fabric.Object): Layer => {
       x         : t.left || 0,
       y         : t.top  || 0,
       width     : t.width || 200,
+      leftPct   : ((t.left || 0) / PAGE_W) * 100,
+      topPct    : ((t.top  || 0) / PAGE_H) * 100,
+      widthPct  : ((t.width || 200) / PAGE_W) * 100,
       fontSize  : t.fontSize,
       fontFamily: t.fontFamily,
       fontWeight: t.fontWeight,
@@ -215,6 +218,10 @@ const objToLayer = (o: fabric.Object): Layer => {
     y      : i.top   || 0,
     width  : i.getScaledWidth(),
     height : i.getScaledHeight(),
+    leftPct  : ((i.left  || 0) / PAGE_W) * 100,
+    topPct   : ((i.top   || 0) / PAGE_H) * 100,
+    widthPct : (i.getScaledWidth()  / PAGE_W) * 100,
+    heightPct: (i.getScaledHeight() / PAGE_H) * 100,
     opacity: i.opacity,
     scaleX : i.scaleX,
     scaleY : i.scaleY,
@@ -691,13 +698,10 @@ window.addEventListener('keydown', onKey)
       const ly: Layer | null = (raw as any).type ? raw as Layer : fromSanity(raw)
       if (!ly) continue
 
-      const fcW = fc.getWidth()
-      const fcH = fc.getHeight()
-
-      if (ly.leftPct != null) ly.x = (ly.leftPct / 100) * fcW
-      if (ly.topPct  != null) ly.y = (ly.topPct  / 100) * fcH
-      if (ly.widthPct  != null) ly.width  = (ly.widthPct  / 100) * fcW
-      if (ly.heightPct != null) ly.height = (ly.heightPct / 100) * fcH
+      if (ly.leftPct != null) ly.x = (ly.leftPct / 100) * PAGE_W
+      if (ly.topPct  != null) ly.y = (ly.topPct  / 100) * PAGE_H
+      if (ly.widthPct  != null) ly.width  = (ly.widthPct  / 100) * PAGE_W
+      if (ly.heightPct != null) ly.height = (ly.heightPct / 100) * PAGE_H
 
 /* ---------- IMAGES --------------------------------------------- */
 if (ly.type === 'image' && (ly.src || ly.srcUrl)) {

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -90,6 +90,12 @@ export interface Layer {
   width:  number
   height?: number
 
+  /** geometry relative to the full canvas (0–100 %) */
+  leftPct?:   number
+  topPct?:    number
+  widthPct?:  number
+  heightPct?: number
+
   opacity?:   number
   scaleX?:    number
   scaleY?:    number

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -8,6 +8,15 @@
 import { urlFor }     from '@/sanity/lib/image'
 import type { Layer } from '@/app/components/FabricCanvas'
 
+/* ---------- page constants (matches FabricCanvas) ---------------- */
+const DPI       = 300
+const mm        = (n: number) => (n / 25.4) * DPI
+const TRIM_W_MM = 150
+const TRIM_H_MM = 214
+const BLEED_MM  = 3
+const PAGE_W    = Math.round(mm(TRIM_W_MM + BLEED_MM * 2))
+const PAGE_H    = Math.round(mm(TRIM_H_MM + BLEED_MM * 2))
+
 /* ───────── helpers ──────────────────────────────────────────────── */
 function isSanityRef(src:any): src is { _type:'image'; asset:{ _ref:string } } {
     return src && typeof src === 'object' && src._type === 'image' && src.asset?._ref
@@ -38,6 +47,10 @@ if (raw._type === 'aiLayer') {
     y : raw.y ?? 100,
     width : raw.w,
     height: raw.h,
+    leftPct:   typeof raw.leftPct === 'number' ? raw.leftPct : ((raw.x ?? 0) / PAGE_W) * 100,
+    topPct:    typeof raw.topPct  === 'number' ? raw.topPct  : ((raw.y ?? 0) / PAGE_H) * 100,
+    widthPct:  typeof raw.widthPct  === 'number' ? raw.widthPct  : (raw.w != null ? (raw.w / PAGE_W) * 100 : undefined),
+    heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
     scaleX: raw.scaleX,
     scaleY: raw.scaleY,
     selectable: !locked,
@@ -61,6 +74,10 @@ if (raw._type === 'aiLayer') {
       y : raw.y ?? 0,
       width : raw.w,
       height: raw.h,
+      leftPct:   typeof raw.leftPct === 'number' ? raw.leftPct : ((raw.x ?? 0) / PAGE_W) * 100,
+      topPct:    typeof raw.topPct  === 'number' ? raw.topPct  : ((raw.y ?? 0) / PAGE_H) * 100,
+      widthPct:  typeof raw.widthPct  === 'number' ? raw.widthPct  : (raw.w != null ? (raw.w / PAGE_W) * 100 : undefined),
+      heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
       scaleX: raw.scaleX,
       scaleY: raw.scaleY,
       ...(raw.cropX != null && { cropX: raw.cropX }),
@@ -81,6 +98,10 @@ if (raw._type === 'aiLayer') {
       x : raw.x ?? 0,
       y : raw.y ?? 0,
       width: raw.width ?? 200,
+      leftPct:   typeof raw.leftPct === 'number' ? raw.leftPct : ((raw.x ?? 0) / PAGE_W) * 100,
+      topPct:    typeof raw.topPct  === 'number' ? raw.topPct  : ((raw.y ?? 0) / PAGE_H) * 100,
+      widthPct:  typeof raw.widthPct  === 'number' ? raw.widthPct  : (raw.width != null ? (raw.width / PAGE_W) * 100 : undefined),
+      heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.height != null ? (raw.height / PAGE_H) * 100 : undefined),
       fontSize  : raw.fontSize,
       fontFamily: raw.fontFamily,
       fontWeight: raw.fontWeight,
@@ -117,6 +138,11 @@ if (layer?._type === 'aiLayer') {
   return {
     ...rest,                                  // keep everything Sanity cares about
 
+    leftPct:   layer.leftPct ?? ((layer.x ?? 0) / PAGE_W) * 100,
+    topPct:    layer.topPct  ?? ((layer.y ?? 0) / PAGE_H) * 100,
+    widthPct:  layer.widthPct  ?? (width != null ? (width / PAGE_W) * 100 : undefined),
+    heightPct: layer.heightPct ?? (height != null ? (height / PAGE_H) * 100 : undefined),
+
     // ── ensure the reference is in the correct shape ───────────────
     source:
       (source?._ref || source?._id)
@@ -136,7 +162,13 @@ if (layer?._type === 'aiLayer') {
   /* —— native Sanity objects (editableImage / editableText) —— */
   if (layer?._type) {
     const { _isAI, selectable, editable, src, assetId, type, ...rest } = layer
-    return rest
+    return {
+      ...rest,
+      leftPct:   layer.leftPct ?? ((layer.x ?? 0) / PAGE_W) * 100,
+      topPct:    layer.topPct  ?? ((layer.y ?? 0) / PAGE_H) * 100,
+      widthPct:  layer.widthPct  ?? (layer.width != null ? (layer.width / PAGE_W) * 100 : undefined),
+      heightPct: layer.heightPct ?? (layer.height != null ? (layer.height / PAGE_H) * 100 : undefined),
+    }
   }
 
 /* —— image layer back to editableImage ——————————————— */
@@ -147,6 +179,10 @@ if (layer.type === 'image') {
     _type: 'editableImage',
     x: layer.x,
     y: layer.y,
+    leftPct:   layer.leftPct ?? ((layer.x ?? 0) / PAGE_W) * 100,
+    topPct:    layer.topPct  ?? ((layer.y ?? 0) / PAGE_H) * 100,
+    widthPct:  layer.widthPct  ?? (layer.width != null ? (layer.width / PAGE_W) * 100 : undefined),
+    heightPct: layer.heightPct ?? (layer.height != null ? (layer.height / PAGE_H) * 100 : undefined),
     ...(layer.width  != null && { w: layer.width  }),
     ...(layer.height != null && { h: layer.height }),
     ...(layer.cropX  != null && { cropX: layer.cropX }),
@@ -184,6 +220,10 @@ else if (typeof layer.src === 'string') {
       text : layer.text,
       x : layer.x,
       y : layer.y,
+      leftPct:   layer.leftPct ?? ((layer.x ?? 0) / PAGE_W) * 100,
+      topPct:    layer.topPct  ?? ((layer.y ?? 0) / PAGE_H) * 100,
+      widthPct:  layer.widthPct  ?? (layer.width != null ? (layer.width / PAGE_W) * 100 : undefined),
+      heightPct: layer.heightPct ?? (layer.height != null ? (layer.height / PAGE_H) * 100 : undefined),
       width: layer.width,
       fontSize  : layer.fontSize,
       fontFamily: layer.fontFamily,


### PR DESCRIPTION
## Summary
- track layer position & size as percentages
- include new fields when converting to/from Sanity
- generate percentages when creating new layers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b399e2de083238df1f868b9a2815a