### PR TITLE
Fix relative layer persistence

### DIFF
--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -37,8 +37,8 @@ export async function POST(req: NextRequest) {
 
       x = clamp(Math.round(x || 0), 0, width)
       y = clamp(Math.round(y || 0), 0, height)
-      w = clamp(Math.round(w || 1), 1, width - x)
-      h = clamp(Math.round(h || 1), 1, height - y)
+      if (w != null) w = clamp(Math.round(w), 1, width - x)
+      if (h != null) h = clamp(Math.round(h), 1, height - y)
 
       if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
         try {
@@ -67,8 +67,8 @@ export async function POST(req: NextRequest) {
                      : ly.textAlign === 'right' ? 'end' : 'start'
         const anchorX = ly.textAlign === 'center' ? '50%'
                         : ly.textAlign === 'right' ? '100%' : '0'
-        const svgW = w || Math.round(fs * Math.max(...lines.map(l => l.length)) * 0.6)
-        const svgH = h || Math.round(lh * lines.length)
+        const svgW = w ?? Math.round(fs * Math.max(...lines.map(l => l.length)) * 0.6)
+        const svgH = h ?? Math.round(lh * lines.length)
         const tspans = lines.map((t,i)=>`<tspan x='${anchorX}' dy='${i?lh:0}'>${t}</tspan>`).join('')
         const svg = `<?xml version='1.0' encoding='UTF-8'?>`+
           `<svg xmlns='http://www.w3.org/2000/svg' width='${svgW}' height='${svgH}'>`+

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { fabric } from 'fabric'
 import sharp from 'sharp'
 
+export const dynamic = 'force-dynamic'
+
+export const dynamic = 'force-dynamic'
+
 const DPI = 300
 const mm = (n:number) => (n / 25.4) * DPI
 
@@ -18,7 +22,7 @@ export async function POST(req: NextRequest) {
     const spec = SPECS[sku]
     const width  = Math.round(mm(spec.trimW + spec.bleed * 2))
     const height = Math.round(mm(spec.trimH + spec.bleed * 2))
-    const canvas = new fabric.StaticCanvas(null, { width, height })
+    const canvas = fabric.createCanvasForNode(width, height)
 
     const page = pages[0] || {}
     const layers = Array.isArray(page.layers) ? page.layers : []
@@ -64,7 +68,7 @@ export async function POST(req: NextRequest) {
     }
 
     canvas.renderAll()
-    const png = Buffer.from(canvas.toDataURL({ format: 'png' }).split(',')[1], 'base64')
+    const png = canvas.toBuffer('image/png')
     let img = sharp(png)
     const masterRatio = (width) / (height)
     const targetRatio = (spec.trimW + spec.bleed * 2) / (spec.trimH + spec.bleed * 2)

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -4,8 +4,6 @@ import sharp from 'sharp'
 
 export const dynamic = 'force-dynamic'
 
-export const dynamic = 'force-dynamic'
-
 const DPI = 300
 const mm = (n:number) => (n / 25.4) * DPI
 

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { fabric } from 'fabric'
+import sharp from 'sharp'
+
+const DPI = 300
+const mm = (n:number) => (n / 25.4) * DPI
+
+const SPECS = {
+  'card-7x5': { trimW: 150, trimH: 214, bleed: 3 },
+} as const
+
+export async function POST(req: NextRequest) {
+  try {
+    const { pages, sku } = await req.json() as { pages:any[]; sku:keyof typeof SPECS }
+    if (!Array.isArray(pages) || !SPECS[sku]) {
+      return NextResponse.json({ error: 'bad input' }, { status: 400 })
+    }
+    const spec = SPECS[sku]
+    const width  = Math.round(mm(spec.trimW + spec.bleed * 2))
+    const height = Math.round(mm(spec.trimH + spec.bleed * 2))
+    const canvas = new fabric.StaticCanvas(null, { width, height })
+
+    const page = pages[0] || {}
+    const layers = Array.isArray(page.layers) ? page.layers : []
+    for (const ly of layers) {
+      const x = ly.leftPct != null ? (ly.leftPct / 100) * width  : ly.x
+      const y = ly.topPct  != null ? (ly.topPct  / 100) * height : ly.y
+      const w = ly.widthPct  != null ? (ly.widthPct  / 100) * width  : ly.width
+      const h = ly.heightPct != null ? (ly.heightPct / 100) * height : ly.height
+      if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
+        await new Promise<void>(resolve => {
+          fabric.Image.fromURL(ly.srcUrl || ly.src, img => {
+            if (!img) return resolve()
+            img.set({ left: x, top: y, originX: 'left', originY: 'top' })
+            if (w && h) {
+              img.scaleToWidth(w)
+              img.scaleToHeight(h)
+            }
+            canvas.add(img)
+            resolve()
+          }, { crossOrigin: 'anonymous' })
+        })
+      } else if (ly.type === 'text') {
+        const txt = new fabric.Textbox(ly.text || '', {
+          left: x,
+          top: y,
+          originX: 'left',
+          originY: 'top',
+          width: w,
+          fontSize: ly.fontSize,
+          fontFamily: ly.fontFamily,
+          fontWeight: ly.fontWeight,
+          fontStyle: ly.fontStyle,
+          underline: ly.underline,
+          fill: ly.fill,
+          textAlign: ly.textAlign,
+          lineHeight: ly.lineHeight,
+          scaleX: ly.scaleX ?? 1,
+          scaleY: ly.scaleY ?? 1,
+          opacity: ly.opacity ?? 1,
+        })
+        canvas.add(txt)
+      }
+    }
+
+    canvas.renderAll()
+    const png = Buffer.from(canvas.toDataURL({ format: 'png' }).split(',')[1], 'base64')
+    let img = sharp(png)
+    const masterRatio = (width) / (height)
+    const targetRatio = (spec.trimW + spec.bleed * 2) / (spec.trimH + spec.bleed * 2)
+    if (targetRatio < masterRatio) {
+      const cropW = Math.round(height * targetRatio)
+      const offsetX = Math.floor((width - cropW) / 2)
+      img = img.extract({ left: offsetX, top: 0, width: cropW, height })
+             .extend({ left: 0, right: 0, top: 0, bottom: 0, background: '#ffffff' })
+    }
+    const out = await img.png().toBuffer()
+    return new NextResponse(out, { headers: { 'content-type': 'image/png' } })
+  } catch (err) {
+    console.error('[proof]', err)
+    return NextResponse.json({ error: 'server' }, { status: 500 })
+  }
+}

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: NextRequest) {
     const spec = SPECS[sku]
     const width  = Math.round(mm(spec.trimW + spec.bleed * 2))
     const height = Math.round(mm(spec.trimH + spec.bleed * 2))
-    const canvas = fabric.createCanvasForNode(width, height)
+    const canvas = new fabric.StaticCanvas(undefined, { width, height })
 
     const page = pages[0] || {}
     const layers = Array.isArray(page.layers) ? page.layers : []

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -24,31 +24,45 @@ export async function POST(req: NextRequest) {
     const width  = Math.round(mm(spec.trimW + spec.bleed * 2))
     const height = Math.round(mm(spec.trimH + spec.bleed * 2))
 
+    const clamp = (n:number, min:number, max:number) => Math.max(min, Math.min(max, n))
     const composites: sharp.OverlayOptions[] = []
     const page = pages[0] || {}
     const layers = Array.isArray(page.layers) ? page.layers : []
 
     for (const ly of layers) {
-      const x = ly.leftPct != null ? (ly.leftPct / 100) * width  : ly.x
-      const y = ly.topPct  != null ? (ly.topPct  / 100) * height : ly.y
-      const w = ly.widthPct  != null ? (ly.widthPct  / 100) * width  : ly.width
-      const h = ly.heightPct != null ? (ly.heightPct / 100) * height : ly.height
+      let x = ly.leftPct != null ? (ly.leftPct / 100) * width  : ly.x
+      let y = ly.topPct  != null ? (ly.topPct  / 100) * height : ly.y
+      let w = ly.widthPct  != null ? (ly.widthPct  / 100) * width  : ly.width
+      let h = ly.heightPct != null ? (ly.heightPct / 100) * height : ly.height
+
+      x = clamp(Math.round(x || 0), 0, width)
+      y = clamp(Math.round(y || 0), 0, height)
+      w = clamp(Math.round(w || 1), 1, width - x)
+      h = clamp(Math.round(h || 1), 1, height - y)
 
       if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
         try {
-          const res = await fetch(ly.srcUrl || ly.src)
+          const url = ly.srcUrl || ly.src
+          if (typeof url !== 'string' || !/^https?:/i.test(url)) continue
+          const res = await fetch(url)
           const buf = Buffer.from(await res.arrayBuffer())
-          const img = await sharp(buf).resize(Math.round(w || 0), Math.round(h || 0)).toBuffer()
-          composites.push({ input: img, left: Math.round(x || 0), top: Math.round(y || 0) })
+          const img = await sharp(buf)
+            .resize(w, h, { fit: 'inside' })
+            .toBuffer()
+          composites.push({ input: img, left: x, top: y })
         } catch (err) {
           console.error('img', err)
         }
       } else if (ly.type === 'text') {
         const fs = ly.fontSize || 20
-        const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='${Math.round(w || 0)}' height='${Math.round(fs*1.2)}'>`+
-          `<text x='0' y='${fs}' font-family='${ly.fontFamily || 'Helvetica'}' font-size='${fs}' font-weight='${ly.fontWeight || ''}' font-style='${ly.fontStyle || ''}' fill='${ly.fill || '#000'}' ${ly.underline ? "text-decoration='underline'" : ''}>${esc(ly.text || '')}</text>`+
+        const lines = String(ly.text || '').split('\n')
+        const lineH = fs * 1.2
+        const svgW = w || Math.round(fs * Math.max(...lines.map(l => l.length)) * 0.6)
+        const svgH = h || Math.round(lineH * lines.length)
+        const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='${svgW}' height='${svgH}'>`+
+          `<text x='0' y='${fs}' font-family='${ly.fontFamily || 'Helvetica'}' font-size='${fs}' font-weight='${ly.fontWeight || ''}' font-style='${ly.fontStyle || ''}' fill='${ly.fill || '#000'}' ${ly.underline ? "text-decoration='underline'" : ''} xml:space='preserve'>${esc(ly.text || '')}</text>`+
           `</svg>`
-        composites.push({ input: Buffer.from(svg), left: Math.round(x || 0), top: Math.round(y || 0) })
+        composites.push({ input: Buffer.from(svg), left: x, top: y })
       }
     }
 

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -20,7 +20,9 @@ function imageUrl(ly: any): string | undefined {
   const ref = ly.assetId || ly.src?.asset?._ref
   if (typeof ref === 'string') {
     const id = ref.replace(/^image-/, '').replace(/-(png|jpg|jpeg|webp)$/, '')
-    const pid = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+    const pid =
+      process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ||
+      process.env.SANITY_STUDIO_PROJECT_ID
     if (pid) return `https://cdn.sanity.io/images/${pid}/production/${id}.png`
   }
   return undefined

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -258,6 +258,37 @@ const handlePreview = () => {
   setPreviewOpen(true)
 }
 
+/* download proof */
+const handleProof = async () => {
+  canvasMap.forEach(fc => {
+    const tool = (fc as any)?._cropTool as CropTool | undefined
+    if (tool?.isActive) tool.commit()
+  })
+  canvasMap.forEach(fc => {
+    const sync = (fc as any)?._syncLayers as (() => void) | undefined
+    if (sync) sync()
+  })
+  const pages = useEditor.getState().pages
+  try {
+    const res = await fetch('/api/proof', {
+      method : 'POST',
+      headers: { 'content-type': 'application/json' },
+      body   : JSON.stringify({ pages, sku: 'card-7x5' }),
+    })
+    if (res.ok) {
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'proof.png'
+      a.click()
+      URL.revokeObjectURL(url)
+    }
+  } catch (err) {
+    console.error('proof', err)
+  }
+}
+
   /* 7 ─ coach-mark ----------------------------------------------- */
   const [anchor, setAnchor] = useState<DOMRect | null>(null)
   const ran = useRef(false)
@@ -308,7 +339,9 @@ const handlePreview = () => {
         onUndo={undo}
         onRedo={redo}
         onSave={handleSave}
+        onProof={mode === 'staff' ? handleProof : undefined}
         saving={saving}
+        mode={mode}
       />
 
       <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -281,7 +281,10 @@ const handleProof = async () => {
       const a = document.createElement('a')
       a.href = url
       a.download = 'proof.png'
+      a.style.display = 'none'
+      document.body.appendChild(a)
       a.click()
+      a.remove()
       URL.revokeObjectURL(url)
     }
   } catch (err) {

--- a/app/components/EditorCommands.tsx
+++ b/app/components/EditorCommands.tsx
@@ -2,16 +2,19 @@
 
 import React from "react";
 import IconButton from "./toolbar/IconButton";
-import { RotateCcw, RotateCw, Save } from "lucide-react";
+import { RotateCcw, RotateCw, Save, Download } from "lucide-react";
 
+type Mode = 'staff' | 'customer';
 interface Props {
   onUndo: () => void;
   onRedo: () => void;
   onSave: () => void | Promise<void>;
+  onProof?: () => void | Promise<void>;
   saving: boolean;
+  mode?: Mode;
 }
 
-export default function EditorCommands({ onUndo, onRedo, onSave, saving }: Props) {
+export default function EditorCommands({ onUndo, onRedo, onSave, onProof, saving, mode = 'customer' }: Props) {
   return (
     <div className="fixed top-14   right-6 z-40 flex items-center gap-3
                      bg-white shadow rounded-md px-3 py-3 pointer-events-auto select-none" style={{ top: "var(--walty-header-h)" }}>
@@ -28,6 +31,16 @@ export default function EditorCommands({ onUndo, onRedo, onSave, saving }: Props
         <Save className="w-5 h-5" />
         {saving ? 'Saving…' : 'Save'}
       </button>
+      {mode === 'staff' && onProof && (
+        <button
+          type="button"
+          onClick={onProof}
+          className="flex items-center gap-1 px-3 py-2 rounded text-[--walty-teal] hover:bg-[--walty-teal]/10"
+        >
+          <Download className="w-5 h-5" />
+          Proof
+        </button>
+      )}
     </div>
   );
 }

--- a/app/components/EditorStore.ts
+++ b/app/components/EditorStore.ts
@@ -149,10 +149,9 @@ export const useEditor = create<EditorState>((set, get) => ({
       x    : 100,
       y    : 100,
       width: 200,
-      leftPct:   (100 / PAGE_W) * 100,
-      topPct:    (100 / PAGE_H) * 100,
-      widthPct:  (200 / PAGE_W) * 100,
-      heightPct: (0 / PAGE_H) * 100,
+      leftPct:  (100 / PAGE_W) * 100,
+      topPct:   (100 / PAGE_H) * 100,
+      widthPct: (200 / PAGE_W) * 100,
     })
 
     set({ pages: nextPages })

--- a/app/components/EditorStore.ts
+++ b/app/components/EditorStore.ts
@@ -5,6 +5,15 @@
 import { create } from 'zustand'
 import type { Layer, TemplatePage } from './FabricCanvas'
 
+/* ---------- shared page constants (matches FabricCanvas) --------- */
+const DPI       = 300
+const mm        = (n: number) => (n / 25.4) * DPI
+const TRIM_W_MM = 150
+const TRIM_H_MM = 214
+const BLEED_MM  = 3
+const PAGE_W    = Math.round(mm(TRIM_W_MM + BLEED_MM * 2))
+const PAGE_H    = Math.round(mm(TRIM_H_MM + BLEED_MM * 2))
+
 /* ---------- helpers ------------------------------------------------ */
 const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v))
 
@@ -140,6 +149,10 @@ export const useEditor = create<EditorState>((set, get) => ({
       x    : 100,
       y    : 100,
       width: 200,
+      leftPct:   (100 / PAGE_W) * 100,
+      topPct:    (100 / PAGE_H) * 100,
+      widthPct:  (200 / PAGE_W) * 100,
+      heightPct: (0 / PAGE_H) * 100,
     })
 
     set({ pages: nextPages })
@@ -163,6 +176,10 @@ export const useEditor = create<EditorState>((set, get) => ({
       x        : 100,
       y        : 100,
       width    : 300,
+      leftPct:   (100 / PAGE_W) * 100,
+      topPct:    (100 / PAGE_H) * 100,
+      widthPct:  (300 / PAGE_W) * 100,
+      heightPct: (300 / PAGE_H) * 100,
       srcUrl   : blobUrl,
       uploading: true,
     } as EditorLayer)

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -194,6 +194,7 @@ const objToLayer = (o: fabric.Object): Layer => {
       leftPct   : ((t.left || 0) / PAGE_W) * 100,
       topPct    : ((t.top  || 0) / PAGE_H) * 100,
       widthPct  : ((t.width || 200) / PAGE_W) * 100,
+      heightPct : (t.getScaledHeight() / PAGE_H) * 100,
       fontSize  : t.fontSize,
       fontFamily: t.fontFamily,
       fontWeight: t.fontWeight,

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -692,7 +692,7 @@ window.addEventListener('keydown', onKey)
     hoverRef.current && fc.add(hoverRef.current)
 
     /* bottom ➜ top keeps original z-order */
-    for (let idx = page.layers.length - 1; idx >= 0; idx--) {
+    for (let idx = 0; idx < page.layers.length; idx++) {
       const raw = page.layers[idx]
       const ly: Layer | null = (raw as any).type ? raw as Layer : fromSanity(raw)
       if (!ly) continue
@@ -813,9 +813,7 @@ img.on('mouseup', () => {
 
           /* keep z-order */
           ;(img as any).layerIdx = idx
-          const pos = fc.getObjects().findIndex(o =>
-            (o as any).layerIdx !== undefined && (o as any).layerIdx < idx)
-          fc.insertAt(img, pos === -1 ? fc.getObjects().length : pos, false)
+          fc.insertAt(img, idx, false)
           img.setCoords()
           fc.requestRenderAll()
           document.dispatchEvent(
@@ -847,7 +845,7 @@ img.on('mouseup', () => {
           lockScalingFlip: true,
         })
         ;(tb as any).layerIdx = idx
-        fc.add(tb)
+        fc.insertAt(tb, idx, false)
       }
     }
 

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -90,6 +90,12 @@ export interface Layer {
   width:  number
   height?: number
 
+  /** geometry relative to the full canvas (0–100 %) */
+  leftPct?:   number
+  topPct?:    number
+  widthPct?:  number
+  heightPct?: number
+
   opacity?:   number
   scaleX?:    number
   scaleY?:    number
@@ -181,6 +187,9 @@ const objToLayer = (o: fabric.Object): Layer => {
       x         : t.left || 0,
       y         : t.top  || 0,
       width     : t.width || 200,
+      leftPct   : ((t.left || 0) / PAGE_W) * 100,
+      topPct    : ((t.top  || 0) / PAGE_H) * 100,
+      widthPct  : ((t.width || 200) / PAGE_W) * 100,
       fontSize  : t.fontSize,
       fontFamily: t.fontFamily,
       fontWeight: t.fontWeight,
@@ -209,6 +218,10 @@ const objToLayer = (o: fabric.Object): Layer => {
     y      : i.top   || 0,
     width  : i.getScaledWidth(),
     height : i.getScaledHeight(),
+    leftPct  : ((i.left  || 0) / PAGE_W) * 100,
+    topPct   : ((i.top   || 0) / PAGE_H) * 100,
+    widthPct : (i.getScaledWidth()  / PAGE_W) * 100,
+    heightPct: (i.getScaledHeight() / PAGE_H) * 100,
     opacity: i.opacity,
     scaleX : i.scaleX,
     scaleY : i.scaleY,
@@ -684,6 +697,11 @@ window.addEventListener('keydown', onKey)
       const raw = page.layers[idx]
       const ly: Layer | null = (raw as any).type ? raw as Layer : fromSanity(raw)
       if (!ly) continue
+
+      if (ly.leftPct != null) ly.x = (ly.leftPct / 100) * PAGE_W
+      if (ly.topPct  != null) ly.y = (ly.topPct  / 100) * PAGE_H
+      if (ly.widthPct  != null) ly.width  = (ly.widthPct  / 100) * PAGE_W
+      if (ly.heightPct != null) ly.height = (ly.heightPct / 100) * PAGE_H
 
 /* ---------- IMAGES --------------------------------------------- */
 if (ly.type === 'image' && (ly.src || ly.srcUrl)) {

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -709,15 +709,17 @@ window.addEventListener('keydown', onKey)
     hoverRef.current && fc.add(hoverRef.current)
 
     /* bottom ➜ top keeps original z-order */
+    const absW = fc.getWidth()
+    const absH = fc.getHeight()
     for (let idx = 0; idx < page.layers.length; idx++) {
       const raw = page.layers[idx]
-      const ly: Layer | null = (raw as any).type ? raw as Layer : fromSanity(raw)
+      const ly: Layer | null = (raw as any).type ? (raw as Layer) : fromSanity(raw)
       if (!ly) continue
 
-      if (ly.leftPct != null) ly.x = (ly.leftPct / 100) * PAGE_W
-      if (ly.topPct  != null) ly.y = (ly.topPct  / 100) * PAGE_H
-      if (ly.widthPct  != null) ly.width  = (ly.widthPct  / 100) * PAGE_W
-      if (ly.heightPct != null) ly.height = (ly.heightPct / 100) * PAGE_H
+      if (ly.leftPct != null) ly.x = (ly.leftPct / 100) * absW
+      if (ly.topPct  != null) ly.y = (ly.topPct  / 100) * absH
+      if (ly.widthPct  != null) ly.width  = (ly.widthPct  / 100) * absW
+      if (ly.heightPct != null) ly.height = (ly.heightPct / 100) * absH
 
 /* ---------- IMAGES --------------------------------------------- */
 if (ly.type === 'image' && (ly.src || ly.srcUrl)) {

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -172,7 +172,12 @@ const getSrcUrl = (raw: Layer): string | undefined => {
       const id = raw.src.asset._ref             // image-xyz-2000x2000-png
         .replace('image-', '')                  // xyz-2000x2000-png
         .replace(/\-(png|jpg|jpeg|webp)$/, '')  // xyz-2000x2000
-      return `https://cdn.sanity.io/images/${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}/production/${id}.png`
+      const pid =
+        process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ||
+        process.env.SANITY_STUDIO_PROJECT_ID
+      return pid
+        ? `https://cdn.sanity.io/images/${pid}/production/${id}.png`
+        : undefined
     }
   
     /* nothing usable yet */

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -244,8 +244,7 @@ const syncLayersFromCanvas = (fc: fabric.Canvas, pageIdx: number) => {
       !(o as any)._backdrop &&
       !(o as any).excludeFromExport &&
       (o as any).type !== 'activeSelection'      // skip wrapper
-    )
-    .reverse();                                  // bottom → top
+    );                                           // bottom → top
 
   /* remember original src on pasted images */
   objs.forEach(o => {

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -482,11 +482,15 @@ addGuides(fc, mode)                           // add guides based on mode
       y      : t.top,
       scaleX : t.scaleX,
       scaleY : t.scaleY,
+      leftPct  : ((t.left  || 0) / PAGE_W) * 100,
+      topPct   : ((t.top   || 0) / PAGE_H) * 100,
     }
     if (t.type === 'image') Object.assign(d, {
       width  : t.getScaledWidth(),
       height : t.getScaledHeight(),
       opacity: t.opacity,
+      widthPct : (t.getScaledWidth()  / PAGE_W) * 100,
+      heightPct: (t.getScaledHeight() / PAGE_H) * 100,
       ...(t.cropX != null && { cropX: t.cropX }),
       ...(t.cropY != null && { cropY: t.cropY }),
       ...(t.width  != null && { cropW: t.width  }),
@@ -503,6 +507,8 @@ addGuides(fc, mode)                           // add guides based on mode
       textAlign  : t.textAlign,
       lineHeight : t.lineHeight,
       opacity    : t.opacity,
+      widthPct  : (t.getScaledWidth()  / PAGE_W) * 100,
+      heightPct : (t.getScaledHeight() / PAGE_H) * 100,
     })
     updateLayer(pageIdx, t.layerIdx, d)
     setTimeout(()=>{ isEditing.current = false })
@@ -525,6 +531,10 @@ addGuides(fc, mode)                           // add guides based on mode
       opacity    : t.opacity,
       width      : t.getScaledWidth(),
       height     : t.getScaledHeight(),
+      leftPct    : ((t.left || 0) / PAGE_W) * 100,
+      topPct     : ((t.top  || 0) / PAGE_H) * 100,
+      widthPct   : (t.getScaledWidth()  / PAGE_W) * 100,
+      heightPct  : (t.getScaledHeight() / PAGE_H) * 100,
     })
     setTimeout(()=>{ isEditing.current = false })
   })

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -96,6 +96,10 @@ export interface Layer {
   widthPct?:  number
   heightPct?: number
 
+  /** image flips */
+  flipX?:     boolean
+  flipY?:     boolean
+
   opacity?:   number
   scaleX?:    number
   scaleY?:    number
@@ -225,6 +229,8 @@ const objToLayer = (o: fabric.Object): Layer => {
     opacity: i.opacity,
     scaleX : i.scaleX,
     scaleY : i.scaleY,
+    flipX  : (i as any).flipX,
+    flipY  : (i as any).flipY,
   }
 
   if (i.cropX != null) layer.cropX = i.cropX
@@ -735,10 +741,15 @@ if (ly.type === 'image' && (ly.src || ly.srcUrl)) {
 
           /* shared props */
           img.set({
-            left: ly.x, top: ly.y, originX: 'left', originY: 'top',
+            left      : ly.x,
+            top       : ly.y,
+            originX   : 'left',
+            originY   : 'top',
             selectable: ly.selectable ?? true,
-            evented: ly.editable ?? true,
-            opacity: ly.opacity ?? 1,
+            evented   : ly.editable ?? true,
+            opacity   : ly.opacity ?? 1,
+            flipX     : ly.flipX ?? false,
+            flipY     : ly.flipY ?? false,
           })
 
           /* ---------- AI placeholder extras -------------------------------- */

--- a/app/components/LayerPanel.tsx
+++ b/app/components/LayerPanel.tsx
@@ -100,7 +100,8 @@ export default function LayerPanel() {
   const [open, setOpen] = useState(true);
 
   if (!pages[activePage]) return null;
-  const ids = pages[activePage].layers.map((_, i) => i.toString());
+  const layerOrder = pages[activePage].layers.map((_, i) => pages[activePage].layers.length - 1 - i);
+  const ids = layerOrder.map(i => i.toString());
 
   /* drag‑and‑drop */
   const sensors = useSensors(useSensor(PointerSensor));
@@ -151,8 +152,8 @@ export default function LayerPanel() {
       <DndContext sensors={sensors} onDragEnd={onDragEnd}>
         <SortableContext items={ids} strategy={verticalListSortingStrategy}>
           <ul className="scrollbar-hidden flex h-[calc(100%-330px)] flex-col gap-1 overflow-y-auto px-4 pb-6">
-            {ids.map((id, i) => (
-              <Row key={id} id={id} idx={i} />
+            {layerOrder.map((idx) => (
+              <Row key={idx} id={idx.toString()} idx={idx} />
             ))}
           </ul>
         </SortableContext>

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -8,6 +8,15 @@
 import { urlFor }     from '@/sanity/lib/image'
 import type { Layer } from '@/app/components/FabricCanvas'
 
+/* ---------- page constants (matches FabricCanvas) ---------------- */
+const DPI       = 300
+const mm        = (n: number) => (n / 25.4) * DPI
+const TRIM_W_MM = 150
+const TRIM_H_MM = 214
+const BLEED_MM  = 3
+const PAGE_W    = Math.round(mm(TRIM_W_MM + BLEED_MM * 2))
+const PAGE_H    = Math.round(mm(TRIM_H_MM + BLEED_MM * 2))
+
 /* ───────── helpers ──────────────────────────────────────────────── */
 function isSanityRef(src:any): src is { _type:'image'; asset:{ _ref:string } } {
     return src && typeof src === 'object' && src._type === 'image' && src.asset?._ref
@@ -38,6 +47,10 @@ if (raw._type === 'aiLayer') {
     y : raw.y ?? 100,
     width : raw.w,
     height: raw.h,
+    leftPct:   typeof raw.leftPct === 'number' ? raw.leftPct : ((raw.x ?? 0) / PAGE_W) * 100,
+    topPct:    typeof raw.topPct  === 'number' ? raw.topPct  : ((raw.y ?? 0) / PAGE_H) * 100,
+    widthPct:  typeof raw.widthPct  === 'number' ? raw.widthPct  : (raw.w != null ? (raw.w / PAGE_W) * 100 : undefined),
+    heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
     scaleX: raw.scaleX,
     scaleY: raw.scaleY,
     selectable: !locked,
@@ -61,6 +74,10 @@ if (raw._type === 'aiLayer') {
       y : raw.y ?? 0,
       width : raw.w,
       height: raw.h,
+      leftPct:   typeof raw.leftPct === 'number' ? raw.leftPct : ((raw.x ?? 0) / PAGE_W) * 100,
+      topPct:    typeof raw.topPct  === 'number' ? raw.topPct  : ((raw.y ?? 0) / PAGE_H) * 100,
+      widthPct:  typeof raw.widthPct  === 'number' ? raw.widthPct  : (raw.w != null ? (raw.w / PAGE_W) * 100 : undefined),
+      heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
       scaleX: raw.scaleX,
       scaleY: raw.scaleY,
       ...(raw.cropX != null && { cropX: raw.cropX }),
@@ -81,6 +98,10 @@ if (raw._type === 'aiLayer') {
       x : raw.x ?? 0,
       y : raw.y ?? 0,
       width: raw.width ?? 200,
+      leftPct:   typeof raw.leftPct === 'number' ? raw.leftPct : ((raw.x ?? 0) / PAGE_W) * 100,
+      topPct:    typeof raw.topPct  === 'number' ? raw.topPct  : ((raw.y ?? 0) / PAGE_H) * 100,
+      widthPct:  typeof raw.widthPct  === 'number' ? raw.widthPct  : (raw.width != null ? (raw.width / PAGE_W) * 100 : undefined),
+      heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.height != null ? (raw.height / PAGE_H) * 100 : undefined),
       fontSize  : raw.fontSize,
       fontFamily: raw.fontFamily,
       fontWeight: raw.fontWeight,
@@ -117,6 +138,11 @@ if (layer?._type === 'aiLayer') {
   return {
     ...rest,                                  // keep everything Sanity cares about
 
+    leftPct:   layer.leftPct ?? ((layer.x ?? 0) / PAGE_W) * 100,
+    topPct:    layer.topPct  ?? ((layer.y ?? 0) / PAGE_H) * 100,
+    widthPct:  layer.widthPct  ?? (width != null ? (width / PAGE_W) * 100 : undefined),
+    heightPct: layer.heightPct ?? (height != null ? (height / PAGE_H) * 100 : undefined),
+
     // ── ensure the reference is in the correct shape ───────────────
     source:
       (source?._ref || source?._id)
@@ -136,7 +162,13 @@ if (layer?._type === 'aiLayer') {
   /* —— native Sanity objects (editableImage / editableText) —— */
   if (layer?._type) {
     const { _isAI, selectable, editable, src, assetId, type, ...rest } = layer
-    return rest
+    return {
+      ...rest,
+      leftPct:   layer.leftPct ?? ((layer.x ?? 0) / PAGE_W) * 100,
+      topPct:    layer.topPct  ?? ((layer.y ?? 0) / PAGE_H) * 100,
+      widthPct:  layer.widthPct  ?? (layer.width != null ? (layer.width / PAGE_W) * 100 : undefined),
+      heightPct: layer.heightPct ?? (layer.height != null ? (layer.height / PAGE_H) * 100 : undefined),
+    }
   }
 
 /* —— image layer back to editableImage ——————————————— */
@@ -147,6 +179,10 @@ if (layer.type === 'image') {
     _type: 'editableImage',
     x: layer.x,
     y: layer.y,
+    leftPct:   layer.leftPct ?? ((layer.x ?? 0) / PAGE_W) * 100,
+    topPct:    layer.topPct  ?? ((layer.y ?? 0) / PAGE_H) * 100,
+    widthPct:  layer.widthPct  ?? (layer.width != null ? (layer.width / PAGE_W) * 100 : undefined),
+    heightPct: layer.heightPct ?? (layer.height != null ? (layer.height / PAGE_H) * 100 : undefined),
     ...(layer.width  != null && { w: layer.width  }),
     ...(layer.height != null && { h: layer.height }),
     ...(layer.cropX  != null && { cropX: layer.cropX }),
@@ -184,6 +220,10 @@ else if (typeof layer.src === 'string') {
       text : layer.text,
       x : layer.x,
       y : layer.y,
+      leftPct:   layer.leftPct ?? ((layer.x ?? 0) / PAGE_W) * 100,
+      topPct:    layer.topPct  ?? ((layer.y ?? 0) / PAGE_H) * 100,
+      widthPct:  layer.widthPct  ?? (layer.width != null ? (layer.width / PAGE_W) * 100 : undefined),
+      heightPct: layer.heightPct ?? (layer.height != null ? (layer.height / PAGE_H) * 100 : undefined),
       width: layer.width,
       fontSize  : layer.fontSize,
       fontFamily: layer.fontFamily,

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -53,6 +53,8 @@ if (raw._type === 'aiLayer') {
     heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
     scaleX: raw.scaleX,
     scaleY: raw.scaleY,
+    ...(raw.flipX != null && { flipX: raw.flipX }),
+    ...(raw.flipY != null && { flipY: raw.flipY }),
     selectable: !locked,
     editable  : !locked,
 
@@ -80,6 +82,8 @@ if (raw._type === 'aiLayer') {
       heightPct: typeof raw.heightPct === 'number' ? raw.heightPct : (raw.h != null ? (raw.h / PAGE_H) * 100 : undefined),
       scaleX: raw.scaleX,
       scaleY: raw.scaleY,
+      ...(raw.flipX != null && { flipX: raw.flipX }),
+      ...(raw.flipY != null && { flipY: raw.flipY }),
       ...(raw.cropX != null && { cropX: raw.cropX }),
       ...(raw.cropY != null && { cropY: raw.cropY }),
       ...(raw.cropW != null && { cropW: raw.cropW }),
@@ -156,6 +160,8 @@ if (layer?._type === 'aiLayer') {
     // ── persist explicit scale adjustments, if any ─────────────────
     ...(scaleX != null && { scaleX }),
     ...(scaleY != null && { scaleY }),
+    ...(layer.flipX != null && { flipX: layer.flipX }),
+    ...(layer.flipY != null && { flipY: layer.flipY }),
   };
 }
 
@@ -192,6 +198,8 @@ if (layer.type === 'image') {
     ...(layer.opacity != null && { opacity: layer.opacity }),
     ...(layer.scaleX  != null && { scaleX: layer.scaleX }),
     ...(layer.scaleY  != null && { scaleY: layer.scaleY }),
+    ...(layer.flipX   != null && { flipX: layer.flipX }),
+    ...(layer.flipY   != null && { flipY: layer.flipY }),
   };
 
 /* 1️⃣ Already have assetId → easiest */


### PR DESCRIPTION
## Summary
- capture percentage geometry when reading objects from Fabric
- hydrate layers using the full page dimensions
- add proof generator API
- staff can download a print proof

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b399e2de083238df1f868b9a2815a