### PR TITLE
Fix proof export to use canvas images

### DIFF
--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -17,7 +17,7 @@ function esc(s: string) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { pages, pageImages, sku } = await req.json() as { pages?:any[]; pageImages?:string[]; sku:Sku }
+    const { pages = [], pageImages, sku } = await req.json() as { pages?:any[]; pageImages?:string[]; sku:Sku }
     if ((!Array.isArray(pages) && !Array.isArray(pageImages)) || !PRINT_SPECS[sku]) {
       return NextResponse.json({ error: 'bad input' }, { status: 400 })
     }

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -16,14 +16,11 @@ import PreviewModal                    from './PreviewModal'
 import { CropTool }                     from '@/lib/CropTool'
 import WaltyEditorHeader                from './WaltyEditorHeader'
 import type { TemplatePage }            from './FabricCanvas'
+import { PRINT_SPECS, inchesToPx }      from '@/lib/printSpecs'
 
 /* ---------- shared page specs (matches FabricCanvas) ------------- */
-const DPI       = 300
-const mm        = (n:number) => (n / 25.4) * DPI
-const TRIM_W_MM = 150
-const TRIM_H_MM = 214
-const BLEED_MM  = 3
-const PAGE_W    = Math.round(mm(TRIM_W_MM + BLEED_MM * 2))
+const spec      = PRINT_SPECS['card-7x5']
+const PAGE_W    = Math.round(inchesToPx(spec.trimW + spec.bleed * 2, spec.dpi))
 const PREVIEW_W = 420
 
 

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -21,7 +21,6 @@ import { PRINT_SPECS, inchesToPx }      from '@/lib/printSpecs'
 /* ---------- shared page specs (matches FabricCanvas) ------------- */
 const spec      = PRINT_SPECS['card-7x5']
 const PAGE_W    = Math.round(inchesToPx(spec.trimW + spec.bleed * 2, spec.dpi))
-const PREVIEW_W = 420
 
 
 /* ---------- helpers ------------------------------------------------ */
@@ -266,7 +265,8 @@ const handlePreview = () => {
 
 /* download proof */
 const handleProof = async () => {
-  const scale = PAGE_W / PREVIEW_W
+  const w = canvasMap[0]?.getWidth() || 420
+  const scale = PAGE_W / w
   const imgs: string[] = []
   canvasMap.forEach((fc, i) => {
     if (!fc) return
@@ -332,7 +332,7 @@ const handleProof = async () => {
     )
   }
 
-  const box = 'flex-shrink-0 w-[420px]'
+  const box = 'flex-shrink-0'
 
   /* ---------------- UI ------------------------------------------ */
   return (

--- a/app/components/EditorStore.ts
+++ b/app/components/EditorStore.ts
@@ -4,15 +4,12 @@
  *********************************************************************/
 import { create } from 'zustand'
 import type { Layer, TemplatePage } from './FabricCanvas'
+import { PRINT_SPECS, inchesToPx } from '@/lib/printSpecs'
 
 /* ---------- shared page constants (matches FabricCanvas) --------- */
-const DPI       = 300
-const mm        = (n: number) => (n / 25.4) * DPI
-const TRIM_W_MM = 150
-const TRIM_H_MM = 214
-const BLEED_MM  = 3
-const PAGE_W    = Math.round(mm(TRIM_W_MM + BLEED_MM * 2))
-const PAGE_H    = Math.round(mm(TRIM_H_MM + BLEED_MM * 2))
+const spec   = PRINT_SPECS['card-7x5']
+const PAGE_W = Math.round(inchesToPx(spec.trimW + spec.bleed * 2, spec.dpi))
+const PAGE_H = Math.round(inchesToPx(spec.trimH + spec.bleed * 2, spec.dpi))
 
 /* ---------- helpers ------------------------------------------------ */
 const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v))

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -12,18 +12,15 @@ import { useEffect, useRef } from 'react'
 import { fabric }            from 'fabric'
 import { useEditor }         from './EditorStore'
 import { fromSanity }        from '@/app/library/layerAdapters'
+import { PRINT_SPECS, inchesToPx, mmToPx } from '@/lib/printSpecs'
 import '@/lib/fabricDefaults'
 import { SEL_COLOR } from '@/lib/fabricDefaults';
 import { CropTool } from '@/lib/CropTool'
 
 /* ---------- size helpers ---------------------------------------- */
-const DPI       = 300
-const mm        = (n: number) => (n / 25.4) * DPI
-const TRIM_W_MM = 150
-const TRIM_H_MM = 214
-const BLEED_MM  = 3
-const PAGE_W    = Math.round(mm(TRIM_W_MM + BLEED_MM * 2))
-const PAGE_H    = Math.round(mm(TRIM_H_MM + BLEED_MM * 2))
+const spec      = PRINT_SPECS['card-7x5']
+const PAGE_W    = Math.round(inchesToPx(spec.trimW + spec.bleed * 2, spec.dpi))
+const PAGE_H    = Math.round(inchesToPx(spec.trimH + spec.bleed * 2, spec.dpi))
 const PREVIEW_W = 420
 const PREVIEW_H = Math.round(PAGE_H * PREVIEW_W / PAGE_W)
 const SCALE     = PREVIEW_W / PAGE_W
@@ -276,7 +273,7 @@ type GuideName = 'safe-zone' | 'bleed'
 
 const addGuides = (fc: fabric.Canvas, mode: Mode) => {
   fc.getObjects().filter(o => (o as any)._guide).forEach(o => fc.remove(o))
-  const strokeW = mm(0.5)
+  const strokeW = mmToPx(0.5, spec.dpi)
   const mk = (
     xy: [number, number, number, number],
     name: GuideName,
@@ -305,7 +302,7 @@ const addGuides = (fc: fabric.Canvas, mode: Mode) => {
   ].forEach(l => fc.add(l))
 
   if (mode === 'staff') {
-    const bleed = mm(BLEED_MM)
+    const bleed = inchesToPx(spec.bleed, spec.dpi)
     ;[
       mk([bleed, bleed, PAGE_W - bleed, bleed], 'bleed', '#f87171'),
       mk([PAGE_W - bleed, bleed, PAGE_W - bleed, PAGE_H - bleed], 'bleed', '#f87171'),

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -268,7 +268,7 @@ const syncLayersFromCanvas = (fc: fabric.Canvas, pageIdx: number) => {
 type Mode = 'staff' | 'customer'
 type GuideName = 'safe-zone' | 'bleed'
 
-const addGuides = (fc: fabric.Canvas, mode: Mode) => {
+const addGuides = (fc: fabric.Canvas, mode: Mode, scale: number) => {
   fc.getObjects().filter(o => (o as any)._guide).forEach(o => fc.remove(o))
   const strokeW = mmToPx(0.5, spec.dpi)
   const mk = (
@@ -280,7 +280,7 @@ const addGuides = (fc: fabric.Canvas, mode: Mode) => {
       new fabric.Line(xy, {
         stroke: color,
         strokeWidth: strokeW,
-        strokeDashArray: dash(6, scaleRef.current),
+        strokeDashArray: dash(6, scale),
         selectable: false,
         evented: false,
         excludeFromExport: true,
@@ -486,7 +486,7 @@ fc.on('mouse:over', e => {
   fc.requestRenderAll()
 })
 
-addGuides(fc, mode)                           // add guides based on mode
+addGuides(fc, mode, scaleRef.current)         // add guides based on mode
   /* ── 4.5 ▸ Fabric ➜ Zustand sync ──────────────────────────── */
   fc.on('object:modified', e=>{
     isEditing.current = true
@@ -892,7 +892,7 @@ img.on('mouseup', () => {
       }
     }
 
-    addGuides(fc, mode)
+    addGuides(fc, mode, scaleRef.current)
     hoverRef.current?.bringToFront()
     fc.requestRenderAll();
     hydrating.current = false

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -7,15 +7,12 @@
 
 import { urlFor }     from '@/sanity/lib/image'
 import type { Layer } from '@/app/components/FabricCanvas'
+import { PRINT_SPECS, inchesToPx } from '@/lib/printSpecs'
 
 /* ---------- page constants (matches FabricCanvas) ---------------- */
-const DPI       = 300
-const mm        = (n: number) => (n / 25.4) * DPI
-const TRIM_W_MM = 150
-const TRIM_H_MM = 214
-const BLEED_MM  = 3
-const PAGE_W    = Math.round(mm(TRIM_W_MM + BLEED_MM * 2))
-const PAGE_H    = Math.round(mm(TRIM_H_MM + BLEED_MM * 2))
+const spec      = PRINT_SPECS['card-7x5']
+const PAGE_W    = Math.round(inchesToPx(spec.trimW + spec.bleed * 2, spec.dpi))
+const PAGE_H    = Math.round(inchesToPx(spec.trimH + spec.bleed * 2, spec.dpi))
 
 /* ───────── helpers ──────────────────────────────────────────────── */
 function isSanityRef(src:any): src is { _type:'image'; asset:{ _ref:string } } {

--- a/lib/printSpecs.ts
+++ b/lib/printSpecs.ts
@@ -1,0 +1,13 @@
+export interface PrintSpec {
+  trimW: number; // inches
+  trimH: number; // inches
+  bleed: number; // inches
+  dpi: number;
+}
+
+export const PRINT_SPECS: Record<string, PrintSpec> = {
+  'card-7x5': { trimW: 7, trimH: 5, bleed: 0.125, dpi: 300 },
+} as const;
+
+export const inchesToPx = (inches: number, dpi: number) => inches * dpi;
+export const mmToPx = (mm: number, dpi: number) => inchesToPx(mm / 25.4, dpi);


### PR DESCRIPTION
## Summary
- include printing constants in `CardEditor`
- generate proof from high-res canvas images instead of layer data
- handle `pageImages` in proof API

## Testing
- `npm run lint` *(fails: React Hook issues and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684b6f898e3083238887a57e10ed3cab