### PR TITLE
Fix Sanity client configuration

### DIFF
--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -47,7 +47,7 @@ export async function getTemplatePages(
     pages[]{
       layers[]{
         ...,
-        'source': source->{
+        source->{
           _id,
           prompt,
           refImage

--- a/sanity/lib/client.ts
+++ b/sanity/lib/client.ts
@@ -3,13 +3,11 @@
   ────────────────────────────────────────────────────────────*/
 
 import {createClient} from '@sanity/client'
+import {apiVersion, dataset, projectId} from '../env'
 
 /*────────────────────────────────────────────────────────────
   Environment variables
   ────────────────────────────────────────────────────────────*/
-const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
-const dataset   = process.env.NEXT_PUBLIC_SANITY_DATASET!
-
 /* Read‑only token (Viewer) used **only** in the card‑editor to
    fetch drafts + published docs. Leave undefined on the public site. */
 const readToken  = process.env.SANITY_READ_TOKEN  || undefined
@@ -23,7 +21,7 @@ const writeToken = process.env.SANITY_WRITE_TOKEN || undefined
 export const sanity = createClient({
   projectId,
   dataset,
-  apiVersion : '2023-10-01',
+  apiVersion,
   perspective: 'published',   // ⇠ only published docs
   useCdn     : true,          // ⇠ fastest / cached
 })
@@ -34,7 +32,7 @@ export const sanity = createClient({
 export const sanityPreview = createClient({
   projectId,
   dataset,
-  apiVersion : '2023-10-01',
+  apiVersion,
   token      : readToken,     // Viewer token
   perspective: 'previewDrafts',
   useCdn     : false,         // drafts never reach the CDN
@@ -46,7 +44,7 @@ export const sanityPreview = createClient({
 export const sanityWriteClient = createClient({
   projectId,
   dataset,
-  apiVersion : '2023-10-01',
+  apiVersion,
   token      : writeToken,    // Contributor token
   perspective: 'previewDrafts',
   useCdn     : false,

--- a/sanity/lib/client.ts
+++ b/sanity/lib/client.ts
@@ -3,7 +3,7 @@
   ────────────────────────────────────────────────────────────*/
 
 import {createClient} from '@sanity/client'
-import {apiVersion, dataset, projectId} from '../env'
+import {apiVersion, dataset, projectId} from '@/sanity/env'
 
 /*────────────────────────────────────────────────────────────
   Environment variables


### PR DESCRIPTION
## Summary
- load Sanity credentials from `sanity/env.ts`
- use shared `apiVersion`/`dataset`/`projectId`

## Testing
- `npm run lint` *(fails: React hook and image lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c22fa2ba08323b5b5dcfe10d38d23