### PR TITLE
Add safe template fetch check

### DIFF
--- a/app/admin/templates/[id]/page.tsx
+++ b/app/admin/templates/[id]/page.tsx
@@ -13,6 +13,7 @@ export const dynamic    = 'force-dynamic' // disable the route cache
 /* ---- imports ---------------------------------------------------- */
 import nextDynamic         from 'next/dynamic'   // ← renamed helper
 import {notFound}          from 'next/navigation'
+import {sanity}            from '@/sanity/lib/client'
 import {getTemplatePages}  from '@/app/library/getTemplatePages'
 
 /* ---- page component -------------------------------------------- */
@@ -22,8 +23,13 @@ export default async function AdminTemplatePage({
   params: {id: string}
 }) {
   /* 1. fetch the *draft* template (404 if missing) */
+  const tpl = await sanity.fetch(
+    '*[_type=="cardTemplate" && _id==$id][0]{ _id }',
+    { id },
+  )
+  if (!tpl) return notFound()
+
   const { pages } = await getTemplatePages(id)
-  if (!pages) notFound()
 
   /* 2. load the client wrapper *only on the client* */
   const EditorWrapper = nextDynamic(

--- a/app/admin/templates/[id]/page.tsx
+++ b/app/admin/templates/[id]/page.tsx
@@ -24,10 +24,22 @@ export default async function AdminTemplatePage({
 }) {
   /* 1. fetch the *draft* template (404 if missing) */
   const tpl = await sanity.fetch(
-    '*[_type=="cardTemplate" && _id==$id][0]{ _id, pages[]{ _key } }',
-    { id },
-  )
-  if (!tpl) return notFound()
+    `*[_type=="cardTemplate" && _id==$id][0]{
+       _id,
+       title,
+       product->{ printSpec },
+       pages[]{
+         _key,
+         name,
+         layers[]{
+           ...,
+           source->{ _id, prompt, refImage }
+         }
+       }
+     }`,
+    { id }
+  );
+  if (!tpl) return notFound();
 
   const { pages } = await getTemplatePages(id)
 

--- a/app/admin/templates/[id]/page.tsx
+++ b/app/admin/templates/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function AdminTemplatePage({
 }) {
   /* 1. fetch the *draft* template (404 if missing) */
   const tpl = await sanity.fetch(
-    '*[_type=="cardTemplate" && _id==$id][0]{ _id }',
+    '*[_type=="cardTemplate" && _id==$id][0]{ _id, pages[]{ _key } }',
     { id },
   )
   if (!tpl) return notFound()


### PR DESCRIPTION
## Summary
- validate admin template ID before loading pages to avoid crash

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_684c429a99588323b0657b933818328e