### PR TITLE
Fix refresh and handle large image uploads

### DIFF
--- a/app/cards/[slug]/customise/page.tsx
+++ b/app/cards/[slug]/customise/page.tsx
@@ -5,6 +5,10 @@
 import CustomiseClient from "./CustomiseClient";
 import { getTemplatePages } from '@/app/library/getTemplatePages'
 
+// Ensure the latest draft is fetched on every visit
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
 // Path: app/cards/[slug]/customise/page.tsx
 // This is a **server component**. In Next 15 `params` is a Promise, so we need to
 // unwrap it with `await` before we read `slug`.


### PR DESCRIPTION
## Summary
- force-dynamic template customisation page so saved drafts load correctly
- downscale large images during upload to keep Fabric stable

## Testing
- `npm run lint` *(fails: React Hooks rules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c7a10b3908323b80f5bc9989d99e0