### PR TITLE
Fix proof crop ratio

### DIFF
--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -120,8 +120,10 @@ export async function POST(req: NextRequest) {
     if (targetRatio < masterRatio) {
       const cropW = Math.round(height * targetRatio)
       const offsetX = Math.floor((width - cropW) / 2)
-      img = img.extract({ left: offsetX, top: 0, width: cropW, height })
-               .extend({ left: 0, right: 0, top: 0, bottom: 0, background: '#ffffff' })
+      img = img
+        .clone()
+        .extract({ left: offsetX, top: 0, width: cropW, height })
+        .extend({ left: offsetX, right: offsetX, top: 0, bottom: 0, background: '#ffffff' })
     }
 
     const out = await img


### PR DESCRIPTION
## Summary
- handle cropping with bleed by cloning the image and restoring the removed area with `extend`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684cb84571848323b91a93884c3ae5c1