### PR TITLE
Upgrade text color picker

### DIFF
--- a/app/components/TextToolbar.tsx
+++ b/app/components/TextToolbar.tsx
@@ -15,6 +15,7 @@ import IconButton              from './toolbar/IconButton'
 import { FontFamilySelect }    from './toolbar/FontFamilySelect'
 import { FontSizeStepper }     from './toolbar/FontSizeStepper'
 import ToolTextOpacitySlider   from './toolbar/ToolTextOpacitySlider'
+import ToolTextColorPicker     from './toolbar/ToolTextColorPicker'
 
 /* lucide-react icons */
 import {
@@ -182,14 +183,8 @@ export default function TextToolbar (props: Props) {
             onChange={(v: number) => mutate({ fontSize: v })}
           />
 
-          {/* colour swatch */}
-          <input
-            disabled={!tb}
-            type="color"
-            value={tb ? (tb.fill as string) : '#000000'}
-            onChange={e => mutate({ fill: e.target.value })}
-            className="h-10 w-10 border rounded disabled:opacity-40"
-          />
+          {/* colour picker */}
+          <ToolTextColorPicker tb={tb} canvas={fc} mutate={mutate} />
 
           {/* centre on page */}
           <IconButton 

--- a/app/components/toolbar/ToolTextColorPicker.tsx
+++ b/app/components/toolbar/ToolTextColorPicker.tsx
@@ -1,0 +1,105 @@
+"use client";
+import { useRef, useState, useEffect } from "react";
+import { fabric } from "fabric";
+import { EyeDropper } from "lucide-react";
+import { HexColorPicker } from "react-colorful";
+import Popover from "./Popover";
+import IconButton from "./IconButton";
+import { Palette } from "lucide-react";
+
+interface Props {
+  tb: fabric.Textbox | null;
+  canvas: fabric.Canvas | null;
+  mutate: (p: Partial<fabric.Textbox>) => void;
+}
+
+export default function ToolTextColorPicker({ tb, canvas, mutate }: Props) {
+  const [open, setOpen] = useState(false);
+  const [color, setColor] = useState("#000000");
+  const [docColors, setDocColors] = useState<string[]>([]);
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (tb) setColor(tb.fill as string);
+  }, [tb]);
+
+  useEffect(() => {
+    if (!open || !canvas) return;
+    const colours = Array.from(
+      new Set(
+        canvas
+          .getObjects()
+          .map(o => (o as any).fill)
+          .filter((c): c is string => typeof c === "string")
+      )
+    ).filter(c => /^#([0-9a-f]{3}){1,2}$/i.test(c));
+    setDocColors(colours as string[]);
+  }, [open, canvas]);
+
+  const handleChange = (val: string) => {
+    setColor(val);
+    if (tb) mutate({ fill: val });
+  };
+
+  const handleEyeDropper = async () => {
+    if (typeof window !== "undefined" && (window as any).EyeDropper) {
+      try {
+        const eye = new (window as any).EyeDropper();
+        const result = await eye.open();
+        handleChange(result.sRGBHex);
+      } catch {
+        /* cancelled */
+      }
+    }
+  };
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        aria-label="Text colour"
+        disabled={!tb}
+        onClick={() => tb && setOpen(o => !o)}
+        className="h-12 w-12 rounded-lg border border-teal-800/10 shadow disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
+        style={{ backgroundColor: tb ? (tb.fill as string) : "#000" }}
+      />
+
+      <Popover anchor={btnRef.current} open={open && !!tb} onClose={() => setOpen(false)}>
+        <div className="space-y-3 w-52" onKeyDown={e => e.stopPropagation()}>
+          <HexColorPicker color={color} onChange={handleChange} aria-label="Choose colour" className="rounded" />
+          <input
+            type="text"
+            value={color}
+            onChange={e => handleChange(e.target.value)}
+            className="w-full rounded border px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
+            aria-label="Hex colour"
+          />
+          {docColors.length > 0 && (
+            <div className="flex flex-wrap gap-1" aria-label="Document colours">
+              {docColors.map(c => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => handleChange(c)}
+                  style={{ backgroundColor: c }}
+                  className="h-6 w-6 rounded border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
+                  aria-label={`Use ${c}`}
+                />
+              ))}
+            </div>
+          )}
+          {typeof window !== "undefined" && (window as any).EyeDropper && (
+            <button
+              type="button"
+              onClick={handleEyeDropper}
+              className="flex items-center gap-1 rounded border px-2 py-1 text-sm hover:bg-teal-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/50"
+            >
+              <EyeDropper className="h-4 w-4" /> Pick colour
+            </button>
+          )}
+        </div>
+      </Popover>
+    </>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^5.5.0",
+    "react-colorful": "^6.2.0",
     "react-konva": "^19.0.3",
     "sanity": "^3.88.1",
     "sanity-plugin-media": "^3.0.2",


### PR DESCRIPTION
## Summary
- use a custom `ToolTextColorPicker` instead of `<input type="color">`
- show pop-over hue picker with document swatches and eyedropper
- add `react-colorful` dependency

## Testing
- `npm run lint` *(fails: React Hooks rules errors and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684d98193f4083238e11e46b894c5a35