### PR TITLE
Improve proof export validation

### DIFF
--- a/app/admin/templates/[id]/EditorWrapper.tsx
+++ b/app/admin/templates/[id]/EditorWrapper.tsx
@@ -44,6 +44,8 @@ export default function EditorWrapper({templateId, initialPages, printSpec}: Pro
     }
   }
 
+  console.log('[EditorWrapper] forwarding spec \u2192', printSpec)
+
   return (
     <>
       {error && (

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -76,6 +76,12 @@ export async function POST(req: NextRequest) {
       if (!meta.format || meta.format === 'unknown') {
         return NextResponse.json({ error: 'no images' }, { status: 400 })
       }
+      const inputRatio = (meta.width || 1) / (meta.height || 1)
+      const targetRatio = width / height
+      if (Math.abs(inputRatio - targetRatio) / targetRatio > 0.01) {
+        console.error('bad ratio', inputRatio, 'vs', targetRatio)
+        return NextResponse.json({ error: 'ratio mismatch' }, { status: 400 })
+      }
       img = sharp(buf).ensureAlpha()
       console.log('Fabric canvas px', meta.width, meta.height)
       console.log('Expected page px', width, height)

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -82,6 +82,13 @@ export async function POST(req: NextRequest) {
         console.error('bad ratio', inputRatio, 'vs', targetRatio)
         return NextResponse.json({ error: 'ratio mismatch' }, { status: 400 })
       }
+      if (
+        (meta.width || 0) < width * 0.75 ||
+        (meta.height || 0) < height * 0.75
+      ) {
+        console.error('image too small', meta.width, meta.height)
+        return NextResponse.json({ error: 'image too small' }, { status: 400 })
+      }
       img = sharp(buf).ensureAlpha()
       console.log('Fabric canvas px', meta.width, meta.height)
       console.log('Expected page px', width, height)

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -71,12 +71,6 @@ export default function CardEditor({
   mode?: Mode
   onSave?: SaveFn
 }) {
-  if (printSpec) {
-    setPrintSpec(printSpec)
-    console.log('CardEditor received spec', printSpec)
-  } else {
-    console.warn('CardEditor missing printSpec')
-  }
   /* 1 ─ hydrate Zustand once ------------------------------------- */
   useEffect(() => {
     useEditor.getState().setPages(
@@ -109,6 +103,23 @@ export default function CardEditor({
   const onReady = (idx: number, fc: fabric.Canvas | null) =>
     setCanvasMap(list => { const next = [...list]; next[idx] = fc; return next })
   const activeFc = canvasMap[activeIdx]
+
+  useEffect(() => {
+    if (!printSpec) {
+      console.warn('CardEditor missing printSpec')
+      return
+    }
+    setPrintSpec(printSpec)
+    console.log('CardEditor received spec', printSpec)
+    const SCALE = 420 / pageW()
+    canvasMap.forEach(fc => {
+      if (!fc) return
+      fc.setWidth(pageW())
+      fc.setHeight(pageH())
+      fc.setViewportTransform([SCALE, 0, 0, SCALE, 0, 0])
+      fc.requestRenderAll()
+    })
+  }, [printSpec, canvasMap])
 
   const [thumbs, setThumbs] = useState<string[]>(['', '', '', ''])
 

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -132,9 +132,16 @@ export default function CardEditor({
   const updateThumbFromCanvas = (idx: number, fc: fabric.Canvas) => {
     try {
       fc.renderAll()
-      console.log('Fabric canvas px', fc.getWidth(), fc.getHeight())
-      console.log('Expected page px', pageW(), pageH())
-      console.log('Export multiplier', EXPORT_MULT())
+      const previewW = (fc as any).lowerCanvasEl?.clientWidth || 0
+      const canvasW  = fc.getWidth()
+      const mult     = canvasW / previewW
+      console.log('thumb export', {
+        previewWidth: previewW,
+        canvasWidth : canvasW,
+        pageW       : pageW(),
+        multiplier  : mult,
+        expectedMult: EXPORT_MULT(),
+      })
       const url = fc.toDataURL({
         format: 'jpeg',
         quality: 0.8,
@@ -293,16 +300,23 @@ const handlePreview = () => {
     const tool = (fc as any)._cropTool as CropTool | undefined
     if (tool?.isActive) tool.commit()
     fc.renderAll()
-    console.log('Fabric canvas px', fc.getWidth(), fc.getHeight())
-    console.log('Expected page px', pageW(), pageH())
-    console.log('Export multiplier', EXPORT_MULT())
-    const ratio = fc.getWidth() / pageW()
+    const previewW = (fc as any).lowerCanvasEl?.clientWidth || 0
+    const canvasW  = fc.getWidth()
+    const mult     = canvasW / previewW
+    console.log('preview export', {
+      previewWidth: previewW,
+      canvasWidth : canvasW,
+      pageW       : pageW(),
+      multiplier  : mult,
+      expectedMult: EXPORT_MULT(),
+    })
+    const ratio = canvasW / pageW()
     if (ratio < 0.95 || ratio > 1.05) {
       console.warn('preview multiplier off', ratio)
       imgs[i] = ''
       return
     }
-    console.log('outgoing preview', fc.getWidth(), fc.getHeight(), EXPORT_MULT())
+    console.log('outgoing preview', canvasW, fc.getHeight(), EXPORT_MULT())
     imgs[i] = fc.toDataURL({
       format: 'png',
       quality: 1,
@@ -328,16 +342,23 @@ const handleProof = async (sku: string) => {
   canvasMap.forEach(fc => {
     if (!fc) { pageImages.push(''); return }
     fc.renderAll()
-    console.log('Fabric canvas px', fc.getWidth(), fc.getHeight())
-    console.log('Expected page px', pageW(), pageH())
-    console.log('Export multiplier', EXPORT_MULT())
-    const ratio = fc.getWidth() / pageW()
+    const previewW = (fc as any).lowerCanvasEl?.clientWidth || 0
+    const canvasW  = fc.getWidth()
+    const mult     = canvasW / previewW
+    console.log('proof export', {
+      previewWidth: previewW,
+      canvasWidth : canvasW,
+      pageW       : pageW(),
+      multiplier  : mult,
+      expectedMult: EXPORT_MULT(),
+    })
+    const ratio = canvasW / pageW()
     if (ratio < 0.95 || ratio > 1.05) {
       console.warn('proof multiplier off', ratio)
       pageImages.push('')
       return
     }
-    console.log('outgoing', sku, fc.getWidth(), fc.getHeight(), EXPORT_MULT())
+    console.log('outgoing', sku, canvasW, fc.getHeight(), EXPORT_MULT())
     pageImages.push(
       fc.toDataURL({ format: 'png', quality: 1, multiplier: EXPORT_MULT() })
     )

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -279,6 +279,7 @@ const handlePreview = () => {
     console.log('Fabric canvas px', fc.getWidth(), fc.getHeight())
     console.log('Expected page px', pageW(), pageH())
     console.log('Export multiplier', EXPORT_MULT())
+    console.log('outgoing preview', fc.getWidth(), fc.getHeight(), EXPORT_MULT())
     imgs[i] = fc.toDataURL({
       format: 'png',
       quality: 1,
@@ -307,6 +308,7 @@ const handleProof = async (sku: string) => {
     console.log('Fabric canvas px', fc.getWidth(), fc.getHeight())
     console.log('Expected page px', pageW(), pageH())
     console.log('Export multiplier', EXPORT_MULT())
+    console.log('outgoing', sku, fc.getWidth(), fc.getHeight(), EXPORT_MULT())
     pageImages.push(
       fc.toDataURL({ format: 'png', quality: 1, multiplier: EXPORT_MULT() })
     )

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -104,11 +104,17 @@ export default function CardEditor({
     setCanvasMap(list => { const next = [...list]; next[idx] = fc; return next })
   const activeFc = canvasMap[activeIdx]
 
+  const prevSpec = useRef<PrintSpec | null>(null)
+
   useEffect(() => {
     if (!printSpec) {
       console.warn('CardEditor missing printSpec')
       return
     }
+    if (prevSpec.current && JSON.stringify(prevSpec.current) === JSON.stringify(printSpec)) {
+      return
+    }
+    prevSpec.current = printSpec
     setPrintSpec(printSpec)
     console.log('CardEditor received spec', printSpec)
     const SCALE = 420 / pageW()
@@ -290,6 +296,12 @@ const handlePreview = () => {
     console.log('Fabric canvas px', fc.getWidth(), fc.getHeight())
     console.log('Expected page px', pageW(), pageH())
     console.log('Export multiplier', EXPORT_MULT())
+    const ratio = fc.getWidth() / pageW()
+    if (ratio < 0.95 || ratio > 1.05) {
+      console.warn('preview multiplier off', ratio)
+      imgs[i] = ''
+      return
+    }
     console.log('outgoing preview', fc.getWidth(), fc.getHeight(), EXPORT_MULT())
     imgs[i] = fc.toDataURL({
       format: 'png',
@@ -319,6 +331,12 @@ const handleProof = async (sku: string) => {
     console.log('Fabric canvas px', fc.getWidth(), fc.getHeight())
     console.log('Expected page px', pageW(), pageH())
     console.log('Export multiplier', EXPORT_MULT())
+    const ratio = fc.getWidth() / pageW()
+    if (ratio < 0.95 || ratio > 1.05) {
+      console.warn('proof multiplier off', ratio)
+      pageImages.push('')
+      return
+    }
     console.log('outgoing', sku, fc.getWidth(), fc.getHeight(), EXPORT_MULT())
     pageImages.push(
       fc.toDataURL({ format: 'png', quality: 1, multiplier: EXPORT_MULT() })

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -711,7 +711,10 @@ window.addEventListener('keydown', onKey)
       window.removeEventListener('keydown', keyCropHandler);
       onReady(null)
       cropToolRef.current?.abort()
-      fc.dispose()
+      if (!(fc as any).__disposed) {
+        (fc as any).__disposed = true
+        fc.dispose()
+      }
     }
 // eslint-disable-next-line react-hooks/exhaustive-deps
 }, [])


### PR DESCRIPTION
## Summary
- validate incoming page images before processing
- add export info logs
- make FabricCanvas disposal idempotent

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d963f0f0c83239578c6861e3d442e