### PR TITLE
Add context menu to canvas

### DIFF
--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  Plus,
+  Scissors,
+  Copy,
+  ClipboardPaste,
+  CopyPlus,
+  Trash2,
+  Crop,
+  Lock,
+} from 'lucide-react';
+
+export type MenuAction =
+  | 'add'
+  | 'cut'
+  | 'copy'
+  | 'paste'
+  | 'duplicate'
+  | 'delete'
+  | 'crop'
+  | 'lock';
+
+interface Props {
+  pos: { x: number; y: number };
+  locked: boolean;
+  onAction: (a: MenuAction) => void;
+  onClose: () => void;
+}
+
+export default function ContextMenu({ pos, locked, onAction, onClose }: Props) {
+  useEffect(() => {
+    const close = () => onClose();
+    const esc = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('mousedown', close);
+    window.addEventListener('contextmenu', close);
+    window.addEventListener('keydown', esc);
+    return () => {
+      window.removeEventListener('mousedown', close);
+      window.removeEventListener('contextmenu', close);
+      window.removeEventListener('keydown', esc);
+    };
+  }, [onClose]);
+
+  const Item = ({ Icon, label, action }: { Icon: any; label: string; action: MenuAction }) => (
+    <button
+      type="button"
+      onClick={() => onAction(action)}
+      className="flex items-center gap-2 px-3 py-1 text-[--walty-teal] hover:bg-[--walty-orange]/10"
+    >
+      <Icon className="w-4 h-4" />
+      <span className="text-sm">{label}</span>
+    </button>
+  );
+
+  return createPortal(
+    <div
+      style={{ top: pos.y, left: pos.x }}
+      className="fixed z-50 bg-white border border-[rgba(0,91,85,.2)] rounded shadow-lg pointer-events-auto"
+    >
+      <div className="flex flex-col py-1">
+        <Item Icon={Plus}          label="Add"        action="add" />
+        <Item Icon={Scissors}      label="Cut"        action="cut" />
+        <Item Icon={Copy}          label="Copy"       action="copy" />
+        <Item Icon={ClipboardPaste} label="Paste"      action="paste" />
+        <Item Icon={CopyPlus}      label="Duplicate"  action="duplicate" />
+        <Item Icon={Trash2}        label="Delete"     action="delete" />
+        <Item Icon={Crop}          label="Crop"       action="crop" />
+        <Item Icon={Lock}          label={locked ? 'Unlock' : 'Lock'} action="lock" />
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -35,11 +35,9 @@ export default function ContextMenu({ pos, locked, onAction, onClose }: Props) {
     const close = () => onClose();
     const esc = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
     window.addEventListener('mousedown', close);
-    window.addEventListener('contextmenu', close);
     window.addEventListener('keydown', esc);
     return () => {
       window.removeEventListener('mousedown', close);
-      window.removeEventListener('contextmenu', close);
       window.removeEventListener('keydown', esc);
     };
   }, [onClose]);

--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import {

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -493,6 +493,12 @@ useEffect(() => {
     backgroundColor       : '#fff',
     preserveObjectStacking: true,
   });
+
+  const ctxMenu = (e: MouseEvent) => {
+    e.preventDefault();
+    setMenuPos({ x: e.clientX, y: e.clientY });
+  };
+  fc.upperCanvasEl.addEventListener('contextmenu', ctxMenu);
   /* --- keep Fabric’s wrapper the same size as the visible preview --- */
   const container = canvasRef.current!.parentElement as HTMLElement | null;
   if (container) {
@@ -769,6 +775,7 @@ window.addEventListener('keydown', onKey)
   fcRef.current = fc; onReady(fc)
 
     return () => {
+      fc.upperCanvasEl.removeEventListener('contextmenu', ctxMenu)
       window.removeEventListener('keydown', onKey)
       if (scrollHandler) window.removeEventListener('scroll', scrollHandler)
       window.removeEventListener('scroll', updateOffset)
@@ -992,10 +999,6 @@ img.on('mouseup', () => {
         ref={canvasRef}
         width={PREVIEW_W}
         height={PREVIEW_H}
-        onContextMenu={e => {
-          e.preventDefault()
-          setMenuPos({ x: e.clientX, y: e.clientY })
-        }}
         style={{ width: PREVIEW_W, height: PREVIEW_H }}   // lock CSS size
         className="border shadow rounded"
       />

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -496,6 +496,7 @@ useEffect(() => {
 
   const ctxMenu = (e: MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     setMenuPos({ x: e.clientX, y: e.clientY });
   };
   fc.upperCanvasEl.addEventListener('contextmenu', ctxMenu);


### PR DESCRIPTION
## Summary
- add `ContextMenu` component
- hook context menu into `FabricCanvas`
- share clipboard helpers and actions with menu

## Testing
- `npm run lint` *(fails: React Hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_684dc955c9208323b51dd3d139bbe463