### PR TITLE
Add preview spec schema and use CMS print specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,6 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 ⚠️  **Image crop is partially implemented – stable build, but crop needs fixes.**
+
+## CMS-driven preview
+Templates store a `previewSpec` and linked product variants. The editor reads this data so every template opens with the correct canvas size and safe-area guides.

--- a/app/admin/templates/[id]/EditorWrapper.tsx
+++ b/app/admin/templates/[id]/EditorWrapper.tsx
@@ -10,15 +10,16 @@ import {useState}   from 'react'
 import {useRouter}  from 'next/navigation'
 
 import CardEditor   from '@/app/components/CardEditor'
-import type {TemplatePage, PrintSpec} from '@/app/components/FabricCanvas'
+import type {TemplatePage, PrintSpec, PreviewSpec} from '@/app/components/FabricCanvas'
 
 interface Props {
   templateId   : string
   initialPages : TemplatePage[]
   printSpec?   : PrintSpec
+  previewSpec? : PreviewSpec
 }
 
-export default function EditorWrapper({templateId, initialPages, printSpec}: Props) {
+export default function EditorWrapper({templateId, initialPages, printSpec, previewSpec}: Props) {
   const router          = useRouter()
   const [error, setErr] = useState<string | null>(null)
 
@@ -57,6 +58,7 @@ export default function EditorWrapper({templateId, initialPages, printSpec}: Pro
         initialPages={initialPages}
         templateId={templateId}
         printSpec={printSpec}
+        previewSpec={previewSpec}
         mode="staff"
         onSave={handleSave}
       />

--- a/app/admin/templates/[id]/EditorWrapper.tsx
+++ b/app/admin/templates/[id]/EditorWrapper.tsx
@@ -11,15 +11,17 @@ import {useRouter}  from 'next/navigation'
 
 import CardEditor   from '@/app/components/CardEditor'
 import type {TemplatePage, PrintSpec, PreviewSpec} from '@/app/components/FabricCanvas'
+import type { TemplateProduct } from '@/app/library/getTemplatePages'
 
 interface Props {
   templateId   : string
   initialPages : TemplatePage[]
   printSpec?   : PrintSpec
   previewSpec? : PreviewSpec
+  products?    : TemplateProduct[]
 }
 
-export default function EditorWrapper({templateId, initialPages, printSpec, previewSpec}: Props) {
+export default function EditorWrapper({templateId, initialPages, printSpec, previewSpec, products}: Props) {
   const router          = useRouter()
   const [error, setErr] = useState<string | null>(null)
 
@@ -59,6 +61,7 @@ export default function EditorWrapper({templateId, initialPages, printSpec, prev
         templateId={templateId}
         printSpec={printSpec}
         previewSpec={previewSpec}
+        products={products}
         mode="staff"
         onSave={handleSave}
       />

--- a/app/admin/templates/[id]/page.tsx
+++ b/app/admin/templates/[id]/page.tsx
@@ -23,25 +23,13 @@ export default async function AdminTemplatePage({
   params: {id: string}
 }) {
   /* 1. fetch the *draft* template (404 if missing) */
-  const tpl = await sanityPreview.fetch(
-    `*[_type=="cardTemplate" && (_id==$id || _id==$draftId)][0]{
-       _id,
-       title,
-      "product": products[0]->{ "printSpec": coalesce(printSpec->, printSpec) },
-       pages[]{
-         _key,
-         name,
-         layers[]{
-           ...,
-           source->{ _id, prompt, refImage }
-         }
-       }
-     }`,
-    { id, draftId: `drafts.${id}` }
-  );
-  if (!tpl) return notFound();
+  const exists = await sanityPreview.fetch(
+    `*[_type=="cardTemplate" && (_id==$id || _id==$draft)][0]._id`,
+    { id, draft: `drafts.${id}` }
+  )
+  if (!exists) return notFound();
 
-  const { pages, spec, previewSpec } = await getTemplatePages(id)
+  const { pages, spec, previewSpec, products } = await getTemplatePages(id)
   console.log('↳ template printSpec', spec)
 
   /* 2. load the client wrapper *only on the client* */
@@ -56,6 +44,7 @@ export default async function AdminTemplatePage({
       initialPages={pages}
       printSpec={spec}
       previewSpec={previewSpec}
+      products={products}
     />
   )
 }

--- a/app/admin/templates/[id]/page.tsx
+++ b/app/admin/templates/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function AdminTemplatePage({
 }) {
   /* 1. fetch the *draft* template (404 if missing) */
   const tpl = await sanity.fetch(
-    `*[_type=="cardTemplate" && _id==$id][0]{
+    `*[_type=="cardTemplate" && (_id==$id || _id==$draftId)][0]{
        _id,
        title,
        "product": products[0]->{ printSpec },
@@ -37,7 +37,7 @@ export default async function AdminTemplatePage({
          }
        }
      }`,
-    { id }
+    { id, draftId: `drafts.${id}` }
   );
   if (!tpl) return notFound();
 

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -31,17 +31,20 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'bad input' }, { status: 400 })
     }
 
-    const spec = sku
+    const specRes = sku
       ? await sanityPreview.fetch<{
-          trimWidthIn: number
-          trimHeightIn: number
-          bleedIn: number
-          dpi: number
-        } | null>(
-          `*[_type=="cardProduct" && slug.current==$sku][0].printSpec->`,
+          spec: {
+            trimWidthIn: number
+            trimHeightIn: number
+            bleedIn: number
+            dpi: number
+          } | null
+        }>(
+          `*[_type=="cardProduct" && slug.current==$sku][0]{"spec":coalesce(printSpec->, printSpec)}`,
           { sku },
         )
       : null
+    const spec = specRes?.spec ?? null
     const fallback = sku ? SPECS[sku as keyof typeof SPECS] : undefined
     const finalSpec = spec ?? fallback
     if (!finalSpec) {

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -21,11 +21,12 @@ function esc(s: string) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { pages, pageImages, id, sku } = (await req.json()) as {
+    const { pages, pageImages, id, sku, filename } = (await req.json()) as {
       pages: any[]
       pageImages?: string[]
       id: string
       sku?: string
+      filename?: string
     }
     if ((!Array.isArray(pages) && !Array.isArray(pageImages)) || typeof id !== 'string') {
       return NextResponse.json({ error: 'bad input' }, { status: 400 })
@@ -158,7 +159,13 @@ export async function POST(req: NextRequest) {
     const out = await img
       .jpeg({ quality: 95, chromaSubsampling: '4:4:4' })
       .toBuffer()
-    return new NextResponse(out, { headers: { 'content-type': 'image/jpeg' } })
+    const name = filename && typeof filename === 'string' ? filename : 'proof.jpg'
+    return new NextResponse(out, {
+      headers: {
+        'content-type': 'image/jpeg',
+        'content-disposition': `attachment; filename="${name}"`,
+      },
+    })
   } catch (err) {
     console.error('[proof]', err)
     return NextResponse.json({ error: 'server' }, { status: 500 })

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: NextRequest) {
           bleedIn: number
           dpi: number
         } | null>(
-          `*[_type=="cardProduct" && slug.current==$sku][0].printSpec`,
+          `*[_type=="cardProduct" && slug.current==$sku][0].printSpec->`,
           { sku },
         )
       : null

--- a/app/api/templates/[id]/route.ts
+++ b/app/api/templates/[id]/route.ts
@@ -55,7 +55,7 @@ export async function PATCH(
     }
 
     const specRes = await sanity.fetch<{spec: PrintSpec | null}>(
-      `*[_type=="cardTemplate" && _id==$id][0]{"spec":products[0]->printSpec->}`,
+      `*[_type=="cardTemplate" && _id==$id][0]{"spec":coalesce(products[0]->printSpec->, products[0]->printSpec)}`,
       { id: params.id }
     )
     const spec = specRes?.spec || {

--- a/app/api/templates/[id]/route.ts
+++ b/app/api/templates/[id]/route.ts
@@ -55,7 +55,7 @@ export async function PATCH(
     }
 
     const specRes = await sanity.fetch<{spec: PrintSpec | null}>(
-      `*[_type=="cardTemplate" && _id==$id][0]{"spec":products[0]->printSpec}`,
+      `*[_type=="cardTemplate" && _id==$id][0]{"spec":products[0]->printSpec->}`,
       { id: params.id }
     )
     const spec = specRes?.spec || {

--- a/app/cards/[slug]/customise/CustomiseClient.tsx
+++ b/app/cards/[slug]/customise/CustomiseClient.tsx
@@ -12,8 +12,16 @@
      // 2️⃣ NEW: put them on window so we can inspect in DevTools
      if (typeof window !== "undefined") {
        (window as any).tplPages = tpl.pages;
+       (window as any).tplPreview = tpl.previewSpec;
      }
    
      // 3️⃣ use customer mode so shoppers get the streamlined editor
-     return <CardEditor initialPages={tpl.pages} printSpec={tpl.spec} mode="customer" />;
+     return (
+       <CardEditor
+         initialPages={tpl.pages}
+         printSpec={tpl.spec}
+         previewSpec={tpl.previewSpec}
+         mode="customer"
+       />
+     );
    }

--- a/app/cards/[slug]/customise/page.tsx
+++ b/app/cards/[slug]/customise/page.tsx
@@ -17,9 +17,9 @@ export default async function CustomisePage({
   // 🡇 open the "params" gift‑box and pull out slug
   const { slug } = await params;
 
-  const { pages, spec } = await getTemplatePages(slug)
+  const { pages, spec, previewSpec } = await getTemplatePages(slug)
   console.log('SERVER tpl.pages =', pages)
   console.log('↳ template printSpec', spec)
 
-  return <CustomiseClient tpl={{ pages, spec }} />;
+  return <CustomiseClient tpl={{ pages, spec, previewSpec }} />;
 }

--- a/app/cards/[slug]/page.tsx
+++ b/app/cards/[slug]/page.tsx
@@ -1,19 +1,28 @@
-import { templates } from "@/data/templates";
 import { notFound } from "next/navigation";
-import { getTemplatePages } from '@/app/library/getTemplatePages'
+import { sanityFetch } from '@/lib/sanityClient'
+import { urlFor } from '@/sanity/lib/image'
 
 export default async function Product({ params }: { params: { slug: string } }) {
-  const tpl = templates.find((t) => t.slug === params.slug)
+  const tpl = await sanityFetch<{
+    title: string
+    slug: { current: string }
+    coverImage?: any
+  }>(
+    `*[_type=="cardTemplate" && slug.current==$slug][0]{title,slug,coverImage}`,
+    { slug: params.slug },
+  )
   if (!tpl) notFound()
-  const { coverImage } = await getTemplatePages(params.slug)
+  const coverImage = tpl.coverImage ? urlFor(tpl.coverImage).url() : undefined
 
   return (
     <main className="p-6 flex flex-col items-center">
-      <img src={coverImage || tpl.cover} alt="" className="w-64 rounded shadow" />
+      {coverImage && (
+        <img src={coverImage} alt="" className="w-64 rounded shadow" />
+      )}
       <h1 className="text-2xl font-bold mt-4">{tpl.title}</h1>
 
       <a
-        href={`/cards/${tpl.slug}/customise`}
+        href={`/cards/${tpl.slug.current}/customise`}
         className="mt-6 px-6 py-2 bg-pink-600 text-white rounded"
       >
         Personalise →

--- a/app/cards/[slug]/page.tsx
+++ b/app/cards/[slug]/page.tsx
@@ -1,9 +1,9 @@
 import { notFound } from "next/navigation";
-import { sanityFetch } from '@/lib/sanityClient'
+import { sanityPreview } from '@/sanity/lib/client'
 import { urlFor } from '@/sanity/lib/image'
 
 export default async function Product({ params }: { params: { slug: string } }) {
-  const tpl = await sanityFetch<{
+  const tpl = await sanityPreview.fetch<{
     title: string
     slug: { current: string }
     coverImage?: any

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -7,7 +7,17 @@ import { useEditor, setEditorSpec }     from './EditorStore'
 if (typeof window !== 'undefined') (window as any).useEditor = useEditor // debug helper
 
 import LayerPanel                       from './LayerPanel'
-import FabricCanvas, { pageW, pageH, EXPORT_MULT, setPrintSpec, PrintSpec } from './FabricCanvas'
+import FabricCanvas, {
+  pageW,
+  pageH,
+  EXPORT_MULT,
+  setPrintSpec,
+  setPreviewSpec,
+  PrintSpec,
+  PreviewSpec,
+  previewW,
+  previewH,
+} from './FabricCanvas'
 import TextToolbar                      from './TextToolbar'
 import ImageToolbar                     from './ImageToolbar'
 import EditorCommands                   from './EditorCommands'
@@ -62,12 +72,14 @@ export default function CardEditor({
   initialPages,
   templateId,
   printSpec,
+  previewSpec,
   mode = 'customer',
   onSave,
 }: {
   initialPages: TemplatePage[] | undefined
   templateId?: string
   printSpec?: PrintSpec
+  previewSpec?: PreviewSpec
   mode?: Mode
   onSave?: SaveFn
 }) {
@@ -77,6 +89,9 @@ export default function CardEditor({
     console.log('CardEditor received spec', printSpec)
   } else {
     console.warn('CardEditor missing printSpec')
+  }
+  if (previewSpec) {
+    setPreviewSpec(previewSpec)
   }
   /* 1 ─ hydrate Zustand once ------------------------------------- */
   useEffect(() => {
@@ -367,7 +382,8 @@ const handleProof = async (sku: string) => {
     )
   }
 
-  const box = 'flex-shrink-0 w-[420px]'
+  const boxWidth = previewW()
+  const box = `flex-shrink-0`
 
   /* ---------------- UI ------------------------------------------ */
   return (
@@ -439,7 +455,7 @@ const handleProof = async (sku: string) => {
                     {/* canvases */}
           <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
             {/* front */}
-            <div className={section === 'front' ? box : 'hidden'}>
+            <div className={section === 'front' ? box : 'hidden'} style={{ width: boxWidth }}>
               <FabricCanvas
                 pageIdx={0}
                 page={pages[0]}
@@ -451,7 +467,7 @@ const handleProof = async (sku: string) => {
             </div>
             {/* inside */}
             <div className={section === 'inside' ? 'flex gap-6' : 'hidden'}>
-              <div className={box}>
+              <div className={box} style={{ width: boxWidth }}>
                 <FabricCanvas
                   pageIdx={1}
                   page={pages[1]}
@@ -461,7 +477,7 @@ const handleProof = async (sku: string) => {
                   mode={mode}
                 />
               </div>
-              <div className={box}>
+              <div className={box} style={{ width: boxWidth }}>
                 <FabricCanvas
                   pageIdx={2}
                   page={pages[2]}
@@ -473,7 +489,7 @@ const handleProof = async (sku: string) => {
               </div>
             </div>
             {/* back */}
-            <div className={section === 'back' ? box : 'hidden'}>
+            <div className={section === 'back' ? box : 'hidden'} style={{ width: boxWidth }}>
               <FabricCanvas
                 pageIdx={3}
                 page={pages[3]}

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -13,6 +13,7 @@ import FabricCanvas, {
   EXPORT_MULT,
   setPrintSpec,
   setPreviewSpec,
+  setSafeInset,
   PrintSpec,
   PreviewSpec,
   previewW,
@@ -96,6 +97,29 @@ export default function CardEditor({
   if (previewSpec) {
     setPreviewSpec(previewSpec)
   }
+  useEffect(() => {
+    if (!printSpec || !previewSpec || !products.length) return
+    const baseW = printSpec.trimWidthIn + printSpec.bleedIn * 2
+    const baseH = printSpec.trimHeightIn + printSpec.bleedIn * 2
+    const baseRatio = baseW / baseH
+    const ratios = products
+      .filter(p => p.showSafeArea)
+      .map(p => p.printSpec)
+      .filter(Boolean)
+      .map(s => (s!.trimWidthIn + s!.bleedIn * 2) / (s!.trimHeightIn + s!.bleedIn * 2))
+    if (!ratios.length) return
+    const minRatio = Math.min(...ratios)
+    let safeW = baseW
+    let safeH = baseH
+    if (minRatio < baseRatio) {
+      safeW = baseH * minRatio
+    } else if (minRatio > baseRatio) {
+      safeH = baseW / minRatio
+    }
+    const insetX = (baseW - safeW) / 2 + printSpec.bleedIn + 0.125
+    const insetY = (baseH - safeH) / 2 + printSpec.bleedIn + 0.125
+    setSafeInset(insetX, insetY)
+  }, [printSpec, previewSpec, products])
   /* 1 ─ hydrate Zustand once ------------------------------------- */
   useEffect(() => {
     useEditor.getState().setPages(

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -381,7 +381,7 @@ const fetchProofBlob = async (
 const handleProofAll = async () => {
   if (!products.length) return
   const { pages, pageImages } = collectProofData()
-  const JSZip = (await import('https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm')).default
+  const JSZip = (await import('jszip')).default
   const zip = new JSZip()
   for (const p of products) {
     const name = `${p.slug}.jpg`

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -347,10 +347,13 @@ const collectProofData = () => {
   const pageImages: string[] = []
   canvasMap.forEach(fc => {
     if (!fc) { pageImages.push(''); return }
+    const guides = fc.getObjects().filter(o => (o as any)._guide)
+    guides.forEach(g => g.set('visible', false))
     fc.renderAll()
     pageImages.push(
       fc.toDataURL({ format: 'png', quality: 1, multiplier: EXPORT_MULT() })
     )
+    guides.forEach(g => g.set('visible', true))
   })
   return { pages, pageImages }
 }

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -381,7 +381,12 @@ const fetchProofBlob = async (
 const handleProofAll = async () => {
   if (!products.length) return
   const { pages, pageImages } = collectProofData()
-  const JSZip = (await import('jszip')).default
+  const JSZip = (
+    await import(
+      /* webpackIgnore: true */
+      'https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm'
+    )
+  ).default
   const zip = new JSZip()
   for (const p of products) {
     const name = `${p.slug}.jpg`

--- a/app/components/EditorCommands.tsx
+++ b/app/components/EditorCommands.tsx
@@ -9,7 +9,7 @@ interface Props {
   onUndo: () => void;
   onRedo: () => void;
   onSave: () => void | Promise<void>;
-  onProof?: (sku: string) => void | Promise<void>;
+  onProof?: () => void | Promise<void>;
   saving: boolean;
   mode?: Mode;
 }
@@ -32,23 +32,14 @@ export default function EditorCommands({ onUndo, onRedo, onSave, onProof, saving
         {saving ? 'Saving…' : 'Save'}
       </button>
       {mode === 'staff' && onProof && (
-        <>
-          {[
-            ['greeting-card-giant', 'Giant'],
-            ['greeting-card-classic', 'Classic'],
-            ['greeting-card-mini', 'Mini'],
-          ].map(([sku, label]) => (
-            <button
-              key={sku}
-              type="button"
-              onClick={() => onProof(sku)}
-              className="flex items-center gap-1 px-3 py-2 rounded text-[--walty-teal] hover:bg-[--walty-teal]/10"
-            >
-              <Download className="w-5 h-5" />
-              {label}
-            </button>
-          ))}
-        </>
+        <button
+          type="button"
+          onClick={() => onProof()}
+          className="flex items-center gap-1 px-3 py-2 rounded text-[--walty-teal] hover:bg-[--walty-teal]/10"
+        >
+          <Download className="w-5 h-5" />
+          Proofs
+        </button>
       )}
     </div>
   );

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -43,6 +43,11 @@ let currentPreview: PreviewSpec = {
   previewHeightPx: 580,
 }
 
+let safeInsetXIn = 0
+let safeInsetYIn = 0
+let SAFE_X = 0
+let SAFE_Y = 0
+
 function recompute() {
   PAGE_W = Math.round((currentSpec.trimWidthIn + currentSpec.bleedIn * 2) * currentSpec.dpi)
   PAGE_H = Math.round((currentSpec.trimHeightIn + currentSpec.bleedIn * 2) * currentSpec.dpi)
@@ -50,11 +55,19 @@ function recompute() {
   PREVIEW_H = currentPreview.previewHeightPx
   SCALE = PREVIEW_W / PAGE_W
   PAD = 4 / SCALE
+  SAFE_X = Math.round(safeInsetXIn * currentSpec.dpi)
+  SAFE_Y = Math.round(safeInsetYIn * currentSpec.dpi)
 }
 
 export const setPrintSpec = (spec: PrintSpec) => {
   console.log('FabricCanvas setSpec', spec.trimWidthIn, spec.trimHeightIn)
   currentSpec = spec
+  recompute()
+}
+
+export const setSafeInset = (xIn: number, yIn: number) => {
+  safeInsetXIn = xIn
+  safeInsetYIn = yIn
   recompute()
 }
 
@@ -369,15 +382,16 @@ const addGuides = (fc: fabric.Canvas, mode: Mode) => {
       { _guide: name },
     )
 
-  /* responsive safe-zone */
-  const safeX = PAGE_W * 0.1
-  const safeY = PAGE_H * 0.05
-  ;[
-    mk([safeX, safeY, PAGE_W - safeX, safeY], 'safe-zone', '#34d399'),
-    mk([PAGE_W - safeX, safeY, PAGE_W - safeX, PAGE_H - safeY], 'safe-zone', '#34d399'),
-    mk([PAGE_W - safeX, PAGE_H - safeY, safeX, PAGE_H - safeY], 'safe-zone', '#34d399'),
-    mk([safeX, PAGE_H - safeY, safeX, safeY], 'safe-zone', '#34d399'),
-  ].forEach(l => fc.add(l))
+  if (SAFE_X > 0 || SAFE_Y > 0) {
+    const safeX = SAFE_X
+    const safeY = SAFE_Y
+    ;[
+      mk([safeX, safeY, PAGE_W - safeX, safeY], 'safe-zone', '#34d399'),
+      mk([PAGE_W - safeX, safeY, PAGE_W - safeX, PAGE_H - safeY], 'safe-zone', '#34d399'),
+      mk([PAGE_W - safeX, PAGE_H - safeY, safeX, PAGE_H - safeY], 'safe-zone', '#34d399'),
+      mk([safeX, PAGE_H - safeY, safeX, safeY], 'safe-zone', '#34d399'),
+    ].forEach(l => fc.add(l))
+  }
 
   if (mode === 'staff') {
     const bleed = mm(currentSpec.bleedIn * 25.4)

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -25,6 +25,12 @@ export interface PrintSpec {
   dpi: number
 }
 
+export interface PreviewSpec {
+  previewWidthPx: number
+  previewHeightPx: number
+  maxMobileWidthPx?: number
+}
+
 let currentSpec: PrintSpec = {
   trimWidthIn: 5,
   trimHeightIn: 7,
@@ -32,10 +38,16 @@ let currentSpec: PrintSpec = {
   dpi: 300,
 }
 
+let currentPreview: PreviewSpec = {
+  previewWidthPx: 420,
+  previewHeightPx: 580,
+}
+
 function recompute() {
   PAGE_W = Math.round((currentSpec.trimWidthIn + currentSpec.bleedIn * 2) * currentSpec.dpi)
   PAGE_H = Math.round((currentSpec.trimHeightIn + currentSpec.bleedIn * 2) * currentSpec.dpi)
-  PREVIEW_H = Math.round(PAGE_H * PREVIEW_W / PAGE_W)
+  PREVIEW_W = currentPreview.previewWidthPx
+  PREVIEW_H = currentPreview.previewHeightPx
   SCALE = PREVIEW_W / PAGE_W
   PAD = 4 / SCALE
 }
@@ -46,12 +58,17 @@ export const setPrintSpec = (spec: PrintSpec) => {
   recompute()
 }
 
+export const setPreviewSpec = (spec: PreviewSpec) => {
+  currentPreview = spec
+  recompute()
+}
+
 /* ---------- size helpers ---------------------------------------- */
-const PREVIEW_W = 420
+let PREVIEW_W = currentPreview.previewWidthPx
 
 let PAGE_W = 0
 let PAGE_H = 0
-let PREVIEW_H = 0
+let PREVIEW_H = currentPreview.previewHeightPx
 let SCALE = 1
 let PAD = 4
 
@@ -61,6 +78,8 @@ const mm = (n: number) => (n / 25.4) * currentSpec.dpi
 
 export const pageW = () => PAGE_W
 export const pageH = () => PAGE_H
+export const previewW = () => PREVIEW_W
+export const previewH = () => PREVIEW_H
 export const EXPORT_MULT = () => {
   const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
   return (1 / SCALE) / dpr
@@ -521,7 +540,7 @@ export default function FabricCanvas ({ pageIdx, page, onReady, isCropping = fal
 useEffect(() => {
   if (!canvasRef.current) return
 
-  // Create Fabric using the <canvas> element’s own dimensions (420 × ??)
+  // Create Fabric using the <canvas> element’s own dimensions
   // – we’ll work in full‑size page units and simply scale the viewport.
   const fc = new fabric.Canvas(canvasRef.current!, {
     backgroundColor       : '#fff',
@@ -543,7 +562,7 @@ useEffect(() => {
     container.style.maxHeight = `${PREVIEW_H}px`;
   }
   addBackdrop(fc);
-  // keep the preview scaled to 420 px wide
+  // keep the preview scaled to the configured width
   fc.setViewportTransform([SCALE, 0, 0, SCALE, 0, 0]);
 
   /* keep event coordinates aligned with any scroll/resize */

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -55,8 +55,11 @@ function recompute() {
   PREVIEW_H = currentPreview.previewHeightPx
   SCALE = PREVIEW_W / PAGE_W
   PAD = 4 / SCALE
-  SAFE_X = Math.round(safeInsetXIn * currentSpec.dpi)
-  SAFE_Y = Math.round(safeInsetYIn * currentSpec.dpi)
+  // compute safe-zone after scaling so rounding happens in preview pixels
+  const safeXPreview = safeInsetXIn * currentSpec.dpi * SCALE
+  const safeYPreview = safeInsetYIn * currentSpec.dpi * SCALE
+  SAFE_X = Math.round(safeXPreview) / SCALE
+  SAFE_Y = Math.round(safeYPreview) / SCALE
 }
 
 export const setPrintSpec = (spec: PrintSpec) => {

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -7,7 +7,7 @@
 import { sanityPreview } from '@/sanity/lib/client'
 import { urlFor } from '@/sanity/lib/image'
 import { fromSanity } from '@/app/library/layerAdapters'
-import type { TemplatePage, PrintSpec } from '@/app/components/FabricCanvas'
+import type { TemplatePage, PrintSpec, PreviewSpec } from '@/app/components/FabricCanvas'
 
 /* ---------- 4-page fallback so the editor always mounts --------- */
 const EMPTY: TemplatePage[] = [
@@ -21,6 +21,7 @@ export interface TemplateData {
   pages: TemplatePage[]
   coverImage?: string
   spec?: PrintSpec
+  previewSpec?: PreviewSpec
 }
 
 /**
@@ -42,7 +43,8 @@ export async function getTemplatePages(
     )
   ] | order(_updatedAt desc)[0]{
     coverImage,
-    "product": products[0]->{ printSpec },
+    previewSpec,
+    "product": products[0]->{ printSpec-> },
     pages[]{
       layers[]{
         ...,                       // keep every native field
@@ -62,7 +64,7 @@ export async function getTemplatePages(
     draftKey: idOrSlug.startsWith('drafts.') ? idOrSlug : `drafts.${idOrSlug}`,
   }
 
-  const raw = await sanityPreview.fetch<{pages?: any[]; coverImage?: any; product?: {printSpec?: PrintSpec}}>(query, params)
+  const raw = await sanityPreview.fetch<{pages?: any[]; coverImage?: any; previewSpec?: PreviewSpec; product?: {printSpec?: PrintSpec}}>(query, params)
 
   const pages = Array.isArray(raw?.pages) && raw.pages.length === 4
     ? raw.pages
@@ -78,6 +80,7 @@ console.log(
 );
 
   const spec = raw?.product?.printSpec as PrintSpec | undefined
+  const previewSpec = raw?.previewSpec as PreviewSpec | undefined
 
   const pagesOut = names.map((name, i) => ({
     name,
@@ -88,5 +91,5 @@ console.log(
 
   const coverImage = raw?.coverImage ? urlFor(raw.coverImage).url() : undefined
 
-  return { pages: pagesOut, coverImage, spec }
+  return { pages: pagesOut, coverImage, spec, previewSpec }
 }

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -44,7 +44,7 @@ export async function getTemplatePages(
   ] | order(_updatedAt desc)[0]{
     coverImage,
     previewSpec,
-    "product": products[0]->{ printSpec-> },
+    "product": products[0]->{ "printSpec": coalesce(printSpec->, printSpec) },
     pages[]{
       layers[]{
         ...,                       // keep every native field
@@ -79,7 +79,7 @@ console.log(
   '\n',
 );
 
-  const spec = raw?.product?.printSpec as PrintSpec | undefined
+  const spec = (raw?.product?.printSpec || undefined) as PrintSpec | undefined
   const previewSpec = raw?.previewSpec as PreviewSpec | undefined
 
   const pagesOut = names.map((name, i) => ({

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -22,6 +22,7 @@ export interface TemplateProduct {
   slug: string
   title: string
   printSpec?: PrintSpec
+  showSafeArea?: boolean
 }
 
 export interface TemplateData {
@@ -56,7 +57,8 @@ export async function getTemplatePages(
       _id,
       title,
       "slug": slug.current,
-      "printSpec": coalesce(printSpec->, printSpec)
+      "printSpec": coalesce(printSpec->, printSpec),
+      showSafeArea
     },
     pages[]{
       layers[]{

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -17,10 +17,13 @@ const DEFAULT_SPEC: PrintSpec = {
   dpi         : 300,
 }
 
-const pageDims = (spec: PrintSpec = DEFAULT_SPEC) => ({
-  PAGE_W: Math.round((spec.trimWidthIn + spec.bleedIn * 2) * spec.dpi),
-  PAGE_H: Math.round((spec.trimHeightIn + spec.bleedIn * 2) * spec.dpi),
-})
+const pageDims = (spec?: PrintSpec | null) => {
+  const s = spec ?? DEFAULT_SPEC
+  return {
+    PAGE_W: Math.round((s.trimWidthIn + s.bleedIn * 2) * s.dpi),
+    PAGE_H: Math.round((s.trimHeightIn + s.bleedIn * 2) * s.dpi),
+  }
+}
 
 /* ───────── helpers ──────────────────────────────────────────────── */
 function isSanityRef(src:any): src is { _type:'image'; asset:{ _ref:string } } {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "purge:assets": "tsx ./scripts/purge-assets.ts",
-    "purge:once": "tsx scripts/purgeTempAssets.ts"
+    "purge:once": "tsx scripts/purgeTempAssets.ts",
+    "migrate:printSpecs": "tsx scripts/migratePrintSpecs.ts"
   },
   "dependencies": {
     "@headlessui/react": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "sanity-plugin-media": "^3.0.2",
     "sharp": "^0.34.1",
     "styled-components": "^6.1.17",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "jszip": "^3.10.1"
   },
   "overrides": {
     "styled-components": "^6.1.17"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "sanity-plugin-media": "^3.0.2",
     "sharp": "^0.34.1",
     "styled-components": "^6.1.17",
-    "zustand": "^5.0.3",
-    "jszip": "^3.10.1"
+    "zustand": "^5.0.3"
   },
   "overrides": {
     "styled-components": "^6.1.17"

--- a/sanity/schemaTypes/cardProduct.ts
+++ b/sanity/schemaTypes/cardProduct.ts
@@ -47,14 +47,17 @@ export default defineType({
     defineField({
       name: 'printSpec',
       title: 'Print specification',
-      type: 'printSpec',
+      type: 'reference',
+      to: [{ type: 'printSpec' }],
       validation: Rule => Rule.required(),
     }),
 
-    /* print specs – the editor can read these if you ever show guides
-       per product */
-    defineField({name:'trimWidthMm',  type:'number', title:'Trim width (mm)',  validation:(R)=>R.required()}),
-    defineField({name:'trimHeightMm', type:'number', title:'Trim height (mm)', validation:(R)=>R.required()}),
-    defineField({name:'pageCount',    type:'number', title:'Pages',            initialValue:4, validation:(R)=>R.required().integer().min(1).max(4)}),
+    defineField({
+      name: 'pageCount',
+      type: 'number',
+      title: 'Pages',
+      initialValue: 4,
+      validation: R => R.required().integer().min(1).max(4),
+    }),
   ],
 })

--- a/sanity/schemaTypes/cardProduct.ts
+++ b/sanity/schemaTypes/cardProduct.ts
@@ -52,6 +52,7 @@ export default defineType({
       validation: Rule => Rule.required(),
     }),
 
+    /* toggle cropping guides for templates using this SKU */
     defineField({
       name: 'showSafeArea',
       type: 'boolean',
@@ -69,4 +70,4 @@ export default defineType({
       validation: R => R.required().integer().min(1).max(4),
     }),
   ],
-})
+

--- a/sanity/schemaTypes/cardProduct.ts
+++ b/sanity/schemaTypes/cardProduct.ts
@@ -53,6 +53,15 @@ export default defineType({
     }),
 
     defineField({
+      name: 'showSafeArea',
+      type: 'boolean',
+      title: 'Show safe-area overlay',
+      initialValue: true,
+      description: 'Display the safe-area guide when editing templates',
+      validation: r => r.required(),
+    }),
+
+    defineField({
       name: 'pageCount',
       type: 'number',
       title: 'Pages',

--- a/sanity/schemaTypes/cardProduct.ts
+++ b/sanity/schemaTypes/cardProduct.ts
@@ -72,3 +72,4 @@ export default defineType({
     }),
   ],
 
+})

--- a/sanity/schemaTypes/cardProduct.ts
+++ b/sanity/schemaTypes/cardProduct.ts
@@ -59,6 +59,7 @@ export default defineType({
       title: 'Show safe-area overlay',
       initialValue: true,
       description: 'Display the safe-area guide when editing templates',
+      options: {layout: 'switch'},
       validation: r => r.required(),
     }),
 

--- a/sanity/schemaTypes/cardTemplate.ts
+++ b/sanity/schemaTypes/cardTemplate.ts
@@ -120,6 +120,34 @@ export default defineType({
       validation: r => r.required(),
     }),
 
+    defineField({
+      name: 'previewSpec',
+      type: 'object',
+      title: 'Preview canvas',
+      group: 'basic',
+      fields: [
+        {
+          name: 'previewWidthPx',
+          type: 'number',
+          title: 'Width (px)',
+          initialValue: 420,
+          validation: r => r.required().positive(),
+        },
+        {
+          name: 'previewHeightPx',
+          type: 'number',
+          title: 'Height (px)',
+          initialValue: 580,
+          validation: r => r.required().positive(),
+        },
+        defineField({
+          name: 'maxMobileWidthPx',
+          type: 'number',
+          title: 'Max mobile width (px)',
+        }),
+      ],
+    }),
+
     /* —— Pages —————————————————————————— */
     defineField({
       name: 'pages',

--- a/sanity/schemaTypes/cardTemplate.ts
+++ b/sanity/schemaTypes/cardTemplate.ts
@@ -257,13 +257,4 @@ export default defineType({
       of: [{type: 'reference', to: [{type: 'relation'}]}],
     }),
   ],
-
-  /* —— publish guard —————————————————— */
-  validation: Rule =>
-    Rule.custom((doc: any) => {
-      if (doc.isLive && (!doc.products || doc.products.length === 0)) {
-        return 'Cannot publish: add at least one product and keep “Visible in store?” ON'
-      }
-      return true
-    }),
 })

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -31,13 +31,13 @@ export const schemaTypes = [
   productMockup,
   page,
   aiPlaceholder,
+  printSpec,
 
   /* objects */
   aiLayer,
   editableImage,
   editableText,
   heroSection,
-  printSpec,
 
   /* facets */
   occasion,

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -4,6 +4,7 @@
 
 import cardTemplate  from './cardTemplate'
 import cardProduct   from './cardProduct'
+import product       from './product'
 import productMockup from './productMockup'
 import sitePage      from './sitePage'
 
@@ -27,6 +28,7 @@ import relation from './relation'   // ← RE-ADDED ✔
 export const schemaTypes = [
   /* documents */
   cardTemplate,
+  product,
   cardProduct,
   productMockup,
   sitePage,

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -5,7 +5,7 @@
 import cardTemplate  from './cardTemplate'
 import cardProduct   from './cardProduct'
 import productMockup from './productMockup'
-import page          from './page'
+import sitePage      from './sitePage'
 
 /* AI-related ---------------------------------------------------- */
 import aiPlaceholder from './aiPlaceholder'
@@ -29,7 +29,7 @@ export const schemaTypes = [
   cardTemplate,
   cardProduct,
   productMockup,
-  page,
+  sitePage,
   aiPlaceholder,
   printSpec,
 

--- a/sanity/schemaTypes/printSpec.ts
+++ b/sanity/schemaTypes/printSpec.ts
@@ -2,7 +2,7 @@ import {defineType, defineField} from 'sanity'
 
 export default defineType({
   name: 'printSpec',
-  type: 'object',
+  type: 'document',
   title: 'Print specification',
   fields: [
     defineField({

--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -1,0 +1,34 @@
+import {defineType, defineField} from 'sanity'
+
+export default defineType({
+  name: 'product',
+  type: 'document',
+  title: 'Product',
+  fields: [
+    defineField({
+      name: 'title',
+      type: 'string',
+      title: 'Product name',
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'slug',
+      type: 'slug',
+      title: 'Slug',
+      options: { source: 'title', maxLength: 96 },
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'description',
+      type: 'text',
+      title: 'Description',
+    }),
+    defineField({
+      name: 'variants',
+      type: 'array',
+      title: 'Variants',
+      of: [{ type: 'reference', to: [{ type: 'cardProduct' }] }],
+      validation: r => r.min(1),
+    }),
+  ],
+})

--- a/sanity/schemaTypes/sitePage.ts
+++ b/sanity/schemaTypes/sitePage.ts
@@ -1,7 +1,7 @@
 import {defineArrayMember, defineField, defineType} from 'sanity'
 
 export default defineType({
-  name: 'page',
+  name: 'sitePage',
   type: 'document',
   title: 'Site page',
   fields: [

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -29,13 +29,155 @@ export const structure: StructureResolver = (S: StructureBuilder) =>
   S.list()
     .title('Content')
     .items([
-      /* day-to-day documents -------------------------------------- */
+      /* ---------------------- Templates branch ------------------ */
       S.listItem()
-        .title('Card templates')
-        .schemaType('cardTemplate')
-        .child(cardTemplateList(S)),
+        .title('Templates')
+        .child(
+          S.list()
+            .title('Templates')
+            .items([
+              S.listItem()
+                .title('All templates')
+                .child(cardTemplateList(S)),
 
-      S.documentTypeListItem('cardProduct').title('Card products'),
+              S.listItem()
+                .title('By product type')
+                .child(
+                  S.list()
+                    .title('By product type')
+                    .items([
+                      S.listItem()
+                        .title('Greeting Cards')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Greeting Cards')
+                            .filter('_type == "cardTemplate" && templateType == "card"')
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Mugs')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Mugs')
+                            .filter('_type == "cardTemplate" && templateType == "mug"')
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Posters')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Posters')
+                            .filter('_type == "cardTemplate" && templateType == "poster"')
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                    ]),
+                ),
+
+              S.listItem()
+                .title('By format')
+                .child(
+                  S.list()
+                    .title('By format')
+                    .items([
+                      S.listItem()
+                        .title('Portrait')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Portrait')
+                            .filter(
+                              '_type == "cardTemplate" && previewSpec.previewHeightPx > previewSpec.previewWidthPx'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Landscape')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Landscape')
+                            .filter(
+                              '_type == "cardTemplate" && previewSpec.previewWidthPx > previewSpec.previewHeightPx'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Square')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Square')
+                            .filter(
+                              '_type == "cardTemplate" && previewSpec.previewWidthPx == previewSpec.previewHeightPx'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                    ]),
+                ),
+
+              S.listItem()
+                .title('By occasion')
+                .child(
+                  S.list()
+                    .title('By occasion')
+                    .items([
+                      S.listItem()
+                        .title('Birthday')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Birthday')
+                            .filter(
+                              '_type == "cardTemplate" && "birthday" in occasion[]->slug.current'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Wedding')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Wedding')
+                            .filter(
+                              '_type == "cardTemplate" && "wedding" in occasion[]->slug.current'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Christmas')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Christmas')
+                            .filter(
+                              '_type == "cardTemplate" && "christmas" in occasion[]->slug.current'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                    ]),
+                ),
+
+              S.listItem()
+                .title('Drafts / Needs review')
+                .child(
+                  S.documentTypeList('cardTemplate')
+                    .title('Drafts / Needs review')
+                    .filter(
+                      '_type == "cardTemplate" && (!isLive || _id in path("drafts.**"))'
+                    )
+                    .child((id) => cardTemplateNode(S, id)),
+                ),
+            ])
+        ),
+
+      S.divider(),
+
+      /* ---------------------- Commerce branch ------------------- */
+      S.listItem()
+        .title('Commerce')
+        .child(
+          S.list()
+            .title('Commerce')
+            .items([
+              S.documentTypeListItem('product').title('Products'),
+              S.documentTypeListItem('cardProduct').title('Variants'),
+              S.documentTypeListItem('printSpec').title('Print specs'),
+            ]),
+        ),
 
       S.documentTypeListItem('sitePage').title('Site pages'),
 

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -37,7 +37,7 @@ export const structure: StructureResolver = (S: StructureBuilder) =>
 
       S.documentTypeListItem('cardProduct').title('Card products'),
 
-      S.documentTypeListItem('page').title('Site pages'),
+      S.documentTypeListItem('sitePage').title('Site pages'),
 
       /* look-ups & presets tucked into a drawer ------------------- */
       S.listItem()

--- a/scripts/migratePrintSpecs.ts
+++ b/scripts/migratePrintSpecs.ts
@@ -1,0 +1,56 @@
+import 'dotenv/config'
+import {createClient} from '@sanity/client'
+import {nanoid} from 'nanoid'
+
+const sanity = createClient({
+  projectId : process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset   : process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  apiVersion: '2025-02-19',
+  token     : process.env.SANITY_SERVICE_TOKEN,
+  useCdn    : false,
+})
+
+async function run() {
+  const products = await sanity.fetch<{
+    _id: string
+    printSpec?: any
+    trimWidthMm?: number
+    trimHeightMm?: number
+  }[]>(`*[_type=="cardProduct"]{_id, printSpec, trimWidthMm, trimHeightMm}`)
+
+  for (const p of products) {
+    if (p.printSpec?._ref) continue
+    const spec = p.printSpec ?? (p.trimWidthMm && p.trimHeightMm ? {
+      trimWidthIn : p.trimWidthMm / 25.4,
+      trimHeightIn: p.trimHeightMm / 25.4,
+      bleedIn     : 0.125,
+      dpi         : 300,
+    } : null)
+    if (!spec) continue
+
+    const q = `*[_type=="printSpec" && trimWidthIn==$w && trimHeightIn==$h && bleedIn==$b && dpi==$d][0]._id`
+    let specId = await sanity.fetch<string|null>(q, {
+      w: spec.trimWidthIn,
+      h: spec.trimHeightIn,
+      b: spec.bleedIn,
+      d: spec.dpi,
+    })
+
+    if (!specId) {
+      specId = `spec-${nanoid()}`
+      await sanity.create({ _id: specId, _type: 'printSpec', ...spec })
+    }
+
+    await sanity.patch(p._id)
+      .set({ printSpec: { _type: 'reference', _ref: specId } })
+      .unset(['trimWidthMm', 'trimHeightMm'])
+      .commit()
+
+    console.log(`✔ migrated ${p._id} → ${specId}`)
+  }
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/migratePrintSpecs.ts
+++ b/scripts/migratePrintSpecs.ts
@@ -41,9 +41,17 @@ async function run() {
       await sanity.create({ _id: specId, _type: 'printSpec', ...spec })
     }
 
-    await sanity.patch(p._id)
+    await sanity
+      .patch(p._id)
       .set({ printSpec: { _type: 'reference', _ref: specId } })
-      .unset(['trimWidthMm', 'trimHeightMm'])
+      .unset([
+        'trimWidthMm',
+        'trimHeightMm',
+        'printSpec.trimWidthIn',
+        'printSpec.trimHeightIn',
+        'printSpec.bleedIn',
+        'printSpec.dpi',
+      ])
       .commit()
 
     console.log(`✔ migrated ${p._id} → ${specId}`)


### PR DESCRIPTION
## Summary
- allow print specs to be documents
- reference print specs from products
- store previewSpec on templates
- wire CardEditor and FabricCanvas to use template previewSpec
- fetch previewSpec in `getTemplatePages`
- dereference printSpec in API routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684dea15c8bc8323a008e2a1fb883290