### PR TITLE
Add crop mode UI and global state

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,6 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 ⚠️  **Image crop is partially implemented – stable build, but crop needs fixes.**
+
+## CMS-driven preview
+Templates store a `previewSpec` and linked product variants. The editor reads this data so every template opens with the correct canvas size and safe-area guides.

--- a/app/admin/templates/[id]/EditorWrapper.tsx
+++ b/app/admin/templates/[id]/EditorWrapper.tsx
@@ -10,15 +10,18 @@ import {useState}   from 'react'
 import {useRouter}  from 'next/navigation'
 
 import CardEditor   from '@/app/components/CardEditor'
-import type {TemplatePage, PrintSpec} from '@/app/components/FabricCanvas'
+import type {TemplatePage, PrintSpec, PreviewSpec} from '@/app/components/FabricCanvas'
+import type { TemplateProduct } from '@/app/library/getTemplatePages'
 
 interface Props {
   templateId   : string
   initialPages : TemplatePage[]
   printSpec?   : PrintSpec
+  previewSpec? : PreviewSpec
+  products?    : TemplateProduct[]
 }
 
-export default function EditorWrapper({templateId, initialPages, printSpec}: Props) {
+export default function EditorWrapper({templateId, initialPages, printSpec, previewSpec, products}: Props) {
   const router          = useRouter()
   const [error, setErr] = useState<string | null>(null)
 
@@ -57,6 +60,8 @@ export default function EditorWrapper({templateId, initialPages, printSpec}: Pro
         initialPages={initialPages}
         templateId={templateId}
         printSpec={printSpec}
+        previewSpec={previewSpec}
+        products={products}
         mode="staff"
         onSave={handleSave}
       />

--- a/app/admin/templates/[id]/page.tsx
+++ b/app/admin/templates/[id]/page.tsx
@@ -13,7 +13,7 @@ export const dynamic    = 'force-dynamic' // disable the route cache
 /* ---- imports ---------------------------------------------------- */
 import nextDynamic         from 'next/dynamic'   // ← renamed helper
 import {notFound}          from 'next/navigation'
-import {sanity}            from '@/sanity/lib/client'
+import {sanityPreview}     from '@/sanity/lib/client'
 import {getTemplatePages}  from '@/app/library/getTemplatePages'
 
 /* ---- page component -------------------------------------------- */
@@ -23,26 +23,13 @@ export default async function AdminTemplatePage({
   params: {id: string}
 }) {
   /* 1. fetch the *draft* template (404 if missing) */
-  const tpl = await sanity.fetch(
-    `*[_type=="cardTemplate" && _id==$id][0]{
-       _id,
-       title,
-       "product": products[0]->{ printSpec },
-       pages[]{
-         _key,
-         name,
-         layers[]{
-           ...,
-           source->{ _id, prompt, refImage }
-         }
-       }
-     }`,
-    { id }
-  );
-  if (!tpl) return notFound();
+  const exists = await sanityPreview.fetch(
+    `*[_type=="cardTemplate" && (_id==$id || _id==$draft)][0]._id`,
+    { id, draft: `drafts.${id}` }
+  )
+  if (!exists) return notFound();
 
-  const { pages } = await getTemplatePages(id)
-  const spec = tpl.product?.printSpec
+  const { pages, spec, previewSpec, products } = await getTemplatePages(id)
   console.log('↳ template printSpec', spec)
 
   /* 2. load the client wrapper *only on the client* */
@@ -51,5 +38,13 @@ export default async function AdminTemplatePage({
     {ssr: false},
   )
 
-  return <EditorWrapper templateId={id} initialPages={pages} printSpec={spec} />
+  return (
+    <EditorWrapper
+      templateId={id}
+      initialPages={pages}
+      printSpec={spec}
+      previewSpec={previewSpec}
+      products={products}
+    />
+  )
 }

--- a/app/api/templates/[id]/route.ts
+++ b/app/api/templates/[id]/route.ts
@@ -55,7 +55,7 @@ export async function PATCH(
     }
 
     const specRes = await sanity.fetch<{spec: PrintSpec | null}>(
-      `*[_type=="cardTemplate" && _id==$id][0]{"spec":products[0]->printSpec}`,
+      `*[_type=="cardTemplate" && _id==$id][0]{"spec":coalesce(products[0]->printSpec->, products[0]->printSpec)}`,
       { id: params.id }
     )
     const spec = specRes?.spec || {

--- a/app/cards/[slug]/customise/CustomiseClient.tsx
+++ b/app/cards/[slug]/customise/CustomiseClient.tsx
@@ -12,8 +12,16 @@
      // 2️⃣ NEW: put them on window so we can inspect in DevTools
      if (typeof window !== "undefined") {
        (window as any).tplPages = tpl.pages;
+       (window as any).tplPreview = tpl.previewSpec;
      }
    
      // 3️⃣ use customer mode so shoppers get the streamlined editor
-     return <CardEditor initialPages={tpl.pages} printSpec={tpl.spec} mode="customer" />;
+     return (
+       <CardEditor
+         initialPages={tpl.pages}
+         printSpec={tpl.spec}
+         previewSpec={tpl.previewSpec}
+         mode="customer"
+       />
+     );
    }

--- a/app/cards/[slug]/customise/page.tsx
+++ b/app/cards/[slug]/customise/page.tsx
@@ -17,9 +17,9 @@ export default async function CustomisePage({
   // 🡇 open the "params" gift‑box and pull out slug
   const { slug } = await params;
 
-  const { pages, spec } = await getTemplatePages(slug)
+  const { pages, spec, previewSpec } = await getTemplatePages(slug)
   console.log('SERVER tpl.pages =', pages)
   console.log('↳ template printSpec', spec)
 
-  return <CustomiseClient tpl={{ pages, spec }} />;
+  return <CustomiseClient tpl={{ pages, spec, previewSpec }} />;
 }

--- a/app/cards/[slug]/page.tsx
+++ b/app/cards/[slug]/page.tsx
@@ -1,19 +1,28 @@
-import { templates } from "@/data/templates";
 import { notFound } from "next/navigation";
-import { getTemplatePages } from '@/app/library/getTemplatePages'
+import { sanityPreview } from '@/sanity/lib/client'
+import { urlFor } from '@/sanity/lib/image'
 
 export default async function Product({ params }: { params: { slug: string } }) {
-  const tpl = templates.find((t) => t.slug === params.slug)
+  const tpl = await sanityPreview.fetch<{
+    title: string
+    slug: { current: string }
+    coverImage?: any
+  }>(
+    `*[_type=="cardTemplate" && slug.current==$slug][0]{title,slug,coverImage}`,
+    { slug: params.slug },
+  )
   if (!tpl) notFound()
-  const { coverImage } = await getTemplatePages(params.slug)
+  const coverImage = tpl.coverImage ? urlFor(tpl.coverImage).url() : undefined
 
   return (
     <main className="p-6 flex flex-col items-center">
-      <img src={coverImage || tpl.cover} alt="" className="w-64 rounded shadow" />
+      {coverImage && (
+        <img src={coverImage} alt="" className="w-64 rounded shadow" />
+      )}
       <h1 className="text-2xl font-bold mt-4">{tpl.title}</h1>
 
       <a
-        href={`/cards/${tpl.slug}/customise`}
+        href={`/cards/${tpl.slug.current}/customise`}
         className="mt-6 px-6 py-2 bg-pink-600 text-white rounded"
       >
         Personalise →

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -12,6 +12,7 @@ import TextToolbar                      from './TextToolbar'
 import ImageToolbar                     from './ImageToolbar'
 import EditorCommands                   from './EditorCommands'
 import SelfieDrawer                     from './SelfieDrawer'
+import CropDrawer                      from './CropDrawer'
 import PreviewModal                    from './PreviewModal'
 import { CropTool }                     from '@/lib/CropTool'
 import WaltyEditorHeader                from './WaltyEditorHeader'
@@ -184,6 +185,9 @@ export default function CardEditor({
   const handleCroppingChange = (idx: number, state: boolean) =>
     setCropping(prev => { const next = [...prev] as typeof prev; next[idx] = state; return next })
 
+  const isCropMode   = useEditor(s => s.isCropMode)
+  const setCropMode  = useEditor(s => s.setCropMode)
+
   /* 5 ─ save ------------------------------------------------------ */
   const [saving, setSaving] = useState(false)
   const handleSave = async () => {
@@ -250,6 +254,24 @@ useEffect(() => {
   return () => document.removeEventListener('open-selfie-drawer', open)
 }, [])
 
+// start-crop → begin crop tool and enter crop mode
+useEffect(() => {
+  const handler = () => {
+    const fc = canvasMap[activeIdx]
+    if (!fc) return
+    const obj = fc.getActiveObject() as any
+    if (!obj || obj.type !== 'image') return
+    const tool = (fc as any)._cropTool as CropTool | undefined
+    if (tool && !tool.isActive) {
+      tool.begin(obj)
+      setCropping(prev => { const n = [...prev] as typeof prev; n[activeIdx] = true; return n })
+      setCropMode(true)
+    }
+  }
+  document.addEventListener('start-crop', handler)
+  return () => document.removeEventListener('start-crop', handler)
+}, [canvasMap, activeIdx])
+
 /* 6 b – when the user picks one of the generated variants ----------- */
 const handleSwap = (url: string) => {
   const pageIdx = activeIdx                         // current page
@@ -267,6 +289,43 @@ const handleSwap = (url: string) => {
   })
 
   setDrawerOpen(false)
+}
+
+const exitCrop = (commit: boolean) => {
+  const fc = canvasMap[activeIdx]
+  const tool = (fc as any)?._cropTool as CropTool | undefined
+  if (tool?.isActive) {
+    commit ? tool.commit() : tool.cancel()
+  }
+  setCropping(prev => { const n = [...prev] as typeof prev; n[activeIdx] = false; return n })
+  setCropMode(false)
+}
+
+const setCropRatio = (r: number | null) => {
+  const fc = canvasMap[activeIdx]
+  const tool = (fc as any)?._cropTool as CropTool | undefined
+  const frame = tool ? (tool as any).frame as fabric.Group | null : null
+  const img = tool ? (tool as any).img as fabric.Image | null : null
+  if (!tool || !tool.isActive || !frame) return
+  if (r === null || Number.isNaN(r)) {
+    frame.lockUniScaling = false
+    fc.requestRenderAll()
+    return
+  }
+  frame.lockUniScaling = true
+  let w = frame.width! * frame.scaleX!
+  let h = frame.height! * frame.scaleY!
+  const cX = frame.left! + w / 2
+  const cY = frame.top! + h / 2
+  const cur = w / h
+  if (Math.abs(cur - r) > 0.01) {
+    if (cur > r) w = h * r
+    else h = w / r
+  }
+  frame.set({ width: w, height: h, scaleX: 1, scaleY: 1, left: cX - w / 2, top: cY - h / 2 })
+  ;(tool as any).clampFrame?.()
+  tool['clamp']?.(true)
+  fc.requestRenderAll()
 }
 
 /* generate images and show preview */
@@ -381,14 +440,16 @@ const handleProof = async (sku: string) => {
         height={72}                          /* match the design */
       />
 
-      <EditorCommands
-        onUndo={undo}
-        onRedo={redo}
-        onSave={handleSave}
-        onProof={mode === 'staff' ? handleProof : undefined}
-        saving={saving}
-        mode={mode}
-      />
+      {!isCropMode && (
+        <EditorCommands
+          onUndo={undo}
+          onRedo={redo}
+          onSave={handleSave}
+          onProof={mode === 'staff' ? handleProof : undefined}
+          saving={saving}
+          mode={mode}
+        />
+      )}
 
       <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
         {/* global overlays */}
@@ -405,14 +466,20 @@ const handleProof = async (sku: string) => {
           onUseSelected={handleSwap}
           placeholderId={aiPlaceholderId}   /* ← NEW prop */
         />
+        <CropDrawer
+          open={isCropMode}
+          onCancel={() => exitCrop(false)}
+          onApply={() => exitCrop(true)}
+          onRatio={setCropRatio}
+        />
 
 
         {/* sidebar */}
-        <LayerPanel />
+        {!isCropMode && <LayerPanel />}
 
         {/* main */}
         <div className="flex flex-col flex-1 min-h-0 mx-auto max-w-[868px]">
-          {activeType === 'text' ? (
+          {!isCropMode && (activeType === 'text' ? (
             <TextToolbar
               canvas={activeFc}
               addText={addText}
@@ -434,7 +501,7 @@ const handleProof = async (sku: string) => {
                 height: 'var(--walty-toolbar-h)',
               }}
             />
-          )}
+          ))}
 
                     {/* canvases */}
           <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -182,8 +182,14 @@ export default function CardEditor({
   /* track cropping state per page */
   const [cropping, setCropping] =
     useState<[boolean, boolean, boolean, boolean]>([false, false, false, false])
-  const handleCroppingChange = (idx: number, state: boolean) =>
-    setCropping(prev => { const next = [...prev] as typeof prev; next[idx] = state; return next })
+  const handleCroppingChange = (idx: number, state: boolean) => {
+    setCropping(prev => {
+      const next = [...prev] as typeof prev
+      next[idx] = state
+      return next
+    })
+    if (idx === activeIdx) setCropMode(state)
+  }
 
   const isCropMode   = useEditor(s => s.isCropMode)
   const setCropMode  = useEditor(s => s.setCropMode)
@@ -303,6 +309,7 @@ const exitCrop = (commit: boolean) => {
 
 const setCropRatio = (r: number | null) => {
   const fc = canvasMap[activeIdx]
+  if (!fc) return
   const tool = (fc as any)?._cropTool as CropTool | undefined
   const frame = tool ? (tool as any).frame as fabric.Group | null : null
   const img = tool ? (tool as any).img as fabric.Image | null : null

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -7,7 +7,18 @@ import { useEditor, setEditorSpec }     from './EditorStore'
 if (typeof window !== 'undefined') (window as any).useEditor = useEditor // debug helper
 
 import LayerPanel                       from './LayerPanel'
-import FabricCanvas, { pageW, pageH, EXPORT_MULT, setPrintSpec, PrintSpec } from './FabricCanvas'
+import FabricCanvas, {
+  pageW,
+  pageH,
+  EXPORT_MULT,
+  setPrintSpec,
+  setPreviewSpec,
+  setSafeInset,
+  PrintSpec,
+  PreviewSpec,
+  previewW,
+  previewH,
+} from './FabricCanvas'
 import TextToolbar                      from './TextToolbar'
 import ImageToolbar                     from './ImageToolbar'
 import EditorCommands                   from './EditorCommands'
@@ -17,6 +28,7 @@ import PreviewModal                    from './PreviewModal'
 import { CropTool }                     from '@/lib/CropTool'
 import WaltyEditorHeader                from './WaltyEditorHeader'
 import type { TemplatePage }            from './FabricCanvas'
+import type { TemplateProduct }         from '@/app/library/getTemplatePages'
 
 
 /* ---------- helpers ------------------------------------------------ */
@@ -63,12 +75,16 @@ export default function CardEditor({
   initialPages,
   templateId,
   printSpec,
+  previewSpec,
+  products = [],
   mode = 'customer',
   onSave,
 }: {
   initialPages: TemplatePage[] | undefined
   templateId?: string
   printSpec?: PrintSpec
+  previewSpec?: PreviewSpec
+  products?: TemplateProduct[]
   mode?: Mode
   onSave?: SaveFn
 }) {
@@ -79,6 +95,32 @@ export default function CardEditor({
   } else {
     console.warn('CardEditor missing printSpec')
   }
+  if (previewSpec) {
+    setPreviewSpec(previewSpec)
+  }
+  useEffect(() => {
+    if (!printSpec || !previewSpec || !products.length) return
+    const baseW = printSpec.trimWidthIn + printSpec.bleedIn * 2
+    const baseH = printSpec.trimHeightIn + printSpec.bleedIn * 2
+    const baseRatio = baseW / baseH
+    const ratios = products
+      .filter(p => p.showSafeArea)
+      .map(p => p.printSpec)
+      .filter(Boolean)
+      .map(s => (s!.trimWidthIn + s!.bleedIn * 2) / (s!.trimHeightIn + s!.bleedIn * 2))
+    if (!ratios.length) return
+    const minRatio = Math.min(...ratios)
+    let safeW = baseW
+    let safeH = baseH
+    if (minRatio < baseRatio) {
+      safeW = baseH * minRatio
+    } else if (minRatio > baseRatio) {
+      safeH = baseW / minRatio
+    }
+    const insetX = (baseW - safeW) / 2 + printSpec.bleedIn + 0.125
+    const insetY = (baseH - safeH) / 2 + printSpec.bleedIn + 0.125
+    setSafeInset(insetX, insetY)
+  }, [printSpec, previewSpec, products])
   /* 1 ─ hydrate Zustand once ------------------------------------- */
   useEffect(() => {
     useEditor.getState().setPages(
@@ -356,8 +398,8 @@ const handlePreview = () => {
   setPreviewOpen(true)
 }
 
-/* download proof */
-const handleProof = async (sku: string) => {
+/* helper – gather pages and rendered images once */
+const collectProofData = () => {
   canvasMap.forEach(fc => {
     const tool = (fc as any)?._cropTool as CropTool | undefined
     if (tool?.isActive) tool.commit()
@@ -366,39 +408,70 @@ const handleProof = async (sku: string) => {
     const sync = (fc as any)?._syncLayers as (() => void) | undefined
     if (sync) sync()
   })
+
   const pages = useEditor.getState().pages
   const pageImages: string[] = []
   canvasMap.forEach(fc => {
     if (!fc) { pageImages.push(''); return }
+    const guides = fc.getObjects().filter(o => (o as any)._guide)
+    guides.forEach(g => g.set('visible', false))
     fc.renderAll()
-    console.log('Fabric canvas px', fc.getWidth(), fc.getHeight())
-    console.log('Expected page px', pageW(), pageH())
-    console.log('Export multiplier', EXPORT_MULT())
     pageImages.push(
       fc.toDataURL({ format: 'png', quality: 1, multiplier: EXPORT_MULT() })
     )
+    guides.forEach(g => g.set('visible', true))
   })
+  return { pages, pageImages }
+}
+
+/* fetch proof blob for one product */
+const fetchProofBlob = async (
+  sku: string,
+  filename: string,
+  pages: any[],
+  pageImages: string[],
+) => {
   try {
     const res = await fetch('/api/proof', {
       method : 'POST',
       headers: { 'content-type': 'application/json' },
-      body   : JSON.stringify({ pages, pageImages, sku, id: templateId }),
+      body   : JSON.stringify({ pages, pageImages, sku, id: templateId, filename }),
     })
     if (res.ok) {
-      const blob = await res.blob()
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = 'proof.jpg'
-      a.style.display = 'none'
-      document.body.appendChild(a)
-      a.click()
-      a.remove()
-      URL.revokeObjectURL(url)
+      return await res.blob()
     }
   } catch (err) {
     console.error('proof', err)
   }
+  return null
+}
+
+/* download proofs for all products */
+const handleProofAll = async () => {
+  if (!products.length) return
+  const { pages, pageImages } = collectProofData()
+  const JSZip = (
+    await import(
+      /* webpackIgnore: true */
+      'https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm'
+    )
+  ).default
+  const zip = new JSZip()
+  for (const p of products) {
+    const name = `${p.slug}.jpg`
+    const blob = await fetchProofBlob(p.slug, name, pages, pageImages)
+    if (blob) zip.file(name, blob)
+  }
+  const out = await zip.generateAsync({ type: 'blob' })
+  const url = URL.createObjectURL(out)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'proofs.zip'
+  a.style.display = 'none'
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
 }
 
   /* 7 ─ coach-mark ----------------------------------------------- */
@@ -433,7 +506,8 @@ const handleProof = async (sku: string) => {
     )
   }
 
-  const box = 'flex-shrink-0 w-[420px]'
+  const boxWidth = previewW()
+  const box = `flex-shrink-0`
 
   /* ---------------- UI ------------------------------------------ */
   return (
@@ -457,7 +531,7 @@ const handleProof = async (sku: string) => {
           mode={mode}
         />
       )}
-
+      
       <div className="flex flex-1 relative bg-[--walty-cream] lg:max-w-6xl mx-auto">
         {/* global overlays */}
         <CoachMark
@@ -513,7 +587,7 @@ const handleProof = async (sku: string) => {
                     {/* canvases */}
           <div className="flex-1 flex justify-center items-start overflow-auto bg-[--walty-cream] pt-6 gap-6">
             {/* front */}
-            <div className={section === 'front' ? box : 'hidden'}>
+            <div className={section === 'front' ? box : 'hidden'} style={{ width: boxWidth }}>
               <FabricCanvas
                 pageIdx={0}
                 page={pages[0]}
@@ -525,7 +599,7 @@ const handleProof = async (sku: string) => {
             </div>
             {/* inside */}
             <div className={section === 'inside' ? 'flex gap-6' : 'hidden'}>
-              <div className={box}>
+              <div className={box} style={{ width: boxWidth }}>
                 <FabricCanvas
                   pageIdx={1}
                   page={pages[1]}
@@ -535,7 +609,7 @@ const handleProof = async (sku: string) => {
                   mode={mode}
                 />
               </div>
-              <div className={box}>
+              <div className={box} style={{ width: boxWidth }}>
                 <FabricCanvas
                   pageIdx={2}
                   page={pages[2]}
@@ -547,7 +621,7 @@ const handleProof = async (sku: string) => {
               </div>
             </div>
             {/* back */}
-            <div className={section === 'back' ? box : 'hidden'}>
+            <div className={section === 'back' ? box : 'hidden'} style={{ width: boxWidth }}>
               <FabricCanvas
                 pageIdx={3}
                 page={pages[3]}

--- a/app/components/CropDrawer.tsx
+++ b/app/components/CropDrawer.tsx
@@ -1,41 +1,35 @@
-"use client"
+"use client";
 
-import { Fragment } from 'react'
-import { Dialog, Transition } from '@headlessui/react'
-import { X, Image as Photo, Square } from 'lucide-react'
+import { Fragment } from "react";
+import { Transition } from "@headlessui/react";
+import { Image as Photo, Square } from "lucide-react";
 
 export interface CropDrawerProps {
-  open: boolean
-  onCancel: () => void
-  onApply: () => void
-  onRatio: (r: number | null) => void
+  open: boolean;
+  onCancel: () => void;
+  onApply: () => void;
+  onRatio: (r: number | null) => void;
 }
 
-const DRAWER_PX = 300
+const DRAWER_PX = 300;
 
-export default function CropDrawer({ open, onCancel, onApply, onRatio }: CropDrawerProps) {
+export default function CropDrawer({
+  open,
+  onCancel,
+  onApply,
+  onRatio,
+}: CropDrawerProps) {
   const ratios: Array<[string, number | null, React.ReactNode]> = [
-    ['Freeform', null, <Square className="w-6 h-6" key="f" />],
-    ['Original', -1, <Photo className="w-6 h-6" key="o" />],
-    ['1:1', 1, <span key="1">1:1</span>],
-    ['4:5', 4/5, <span key="2">4:5</span>],
-    ['16:9', 16/9, <span key="3">16:9</span>],
-    ['9:16', 9/16, <span key="4">9:16</span>],
-  ]
+    ["Freeform", null, <Square className="w-6 h-6" key="f" />],
+    ["Original", -1, <Photo className="w-6 h-6" key="o" />],
+    ["1:1", 1, <span key="1">1:1</span>],
+    ["4:5", 4 / 5, <span key="2">4:5</span>],
+    ["16:9", 16 / 9, <span key="3">16:9</span>],
+    ["9:16", 9 / 16, <span key="4">9:16</span>],
+  ];
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="fixed inset-0 z-50 flex" onClose={onCancel}>
-        <Transition.Child
-          as={Fragment}
-          enter="transition-opacity ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="transition-opacity ease-in duration-300"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-black/20 backdrop-blur-sm" aria-hidden />
-        </Transition.Child>
+      <div className="fixed inset-0 z-50 flex pointer-events-none">
         <Transition.Child
           as={Fragment}
           enter="transform transition ease-out duration-300"
@@ -45,11 +39,16 @@ export default function CropDrawer({ open, onCancel, onApply, onRatio }: CropDra
           leaveFrom="translate-x-0"
           leaveTo="translate-x-full"
         >
-          <div className="ml-auto h-full" style={{ width: DRAWER_PX }}>
+          <div
+            className="ml-auto h-full pointer-events-auto"
+            style={{ width: DRAWER_PX }}
+          >
             <div className="flex flex-col h-full bg-white shadow-xl">
               <header className="flex items-center justify-between px-4 py-3 shadow">
                 <h2 className="text-sm font-medium">Crop</h2>
-                <button onClick={onCancel} className="text-xl leading-none">×</button>
+                <button onClick={onCancel} className="text-xl leading-none">
+                  ×
+                </button>
               </header>
               <section className="flex-1 overflow-auto p-4">
                 <div className="grid grid-cols-2 gap-3">
@@ -66,7 +65,9 @@ export default function CropDrawer({ open, onCancel, onApply, onRatio }: CropDra
                 </div>
               </section>
               <footer className="flex justify-end gap-2 px-4 py-3 border-t">
-                <button onClick={onCancel} className="text-gray-600">Cancel</button>
+                <button onClick={onCancel} className="text-gray-600">
+                  Cancel
+                </button>
                 <button
                   onClick={onApply}
                   className="rounded-md bg-[--walty-orange] text-white px-4 py-1"
@@ -77,7 +78,7 @@ export default function CropDrawer({ open, onCancel, onApply, onRatio }: CropDra
             </div>
           </div>
         </Transition.Child>
-      </Dialog>
+      </div>
     </Transition.Root>
-  )
+  );
 }

--- a/app/components/CropDrawer.tsx
+++ b/app/components/CropDrawer.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { Fragment } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+import { X, Image as Photo, Square } from 'lucide-react'
+
+export interface CropDrawerProps {
+  open: boolean
+  onCancel: () => void
+  onApply: () => void
+  onRatio: (r: number | null) => void
+}
+
+const DRAWER_PX = 300
+
+export default function CropDrawer({ open, onCancel, onApply, onRatio }: CropDrawerProps) {
+  const ratios: Array<[string, number | null, React.ReactNode]> = [
+    ['Freeform', null, <Square className="w-6 h-6" key="f" />],
+    ['Original', -1, <Photo className="w-6 h-6" key="o" />],
+    ['1:1', 1, <span key="1">1:1</span>],
+    ['4:5', 4/5, <span key="2">4:5</span>],
+    ['16:9', 16/9, <span key="3">16:9</span>],
+    ['9:16', 9/16, <span key="4">9:16</span>],
+  ]
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="fixed inset-0 z-50 flex" onClose={onCancel}>
+        <Transition.Child
+          as={Fragment}
+          enter="transition-opacity ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="transition-opacity ease-in duration-300"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/20 backdrop-blur-sm" aria-hidden />
+        </Transition.Child>
+        <Transition.Child
+          as={Fragment}
+          enter="transform transition ease-out duration-300"
+          enterFrom="translate-x-full"
+          enterTo="translate-x-0"
+          leave="transform transition ease-in duration-300"
+          leaveFrom="translate-x-0"
+          leaveTo="translate-x-full"
+        >
+          <div className="ml-auto h-full" style={{ width: DRAWER_PX }}>
+            <div className="flex flex-col h-full bg-white shadow-xl">
+              <header className="flex items-center justify-between px-4 py-3 shadow">
+                <h2 className="text-sm font-medium">Crop</h2>
+                <button onClick={onCancel} className="text-xl leading-none">×</button>
+              </header>
+              <section className="flex-1 overflow-auto p-4">
+                <div className="grid grid-cols-2 gap-3">
+                  {ratios.map(([label, r, icon]) => (
+                    <button
+                      key={label}
+                      onClick={() => onRatio(r === -1 ? NaN : r)}
+                      className="flex flex-col items-center justify-center w-16 h-16 rounded-md border border-gray-300 hover:ring-2 hover:ring-[--walty-teal]"
+                    >
+                      {icon}
+                      <span className="text-xs mt-1">{label}</span>
+                    </button>
+                  ))}
+                </div>
+              </section>
+              <footer className="flex justify-end gap-2 px-4 py-3 border-t">
+                <button onClick={onCancel} className="text-gray-600">Cancel</button>
+                <button
+                  onClick={onApply}
+                  className="rounded-md bg-[--walty-orange] text-white px-4 py-1"
+                >
+                  Apply
+                </button>
+              </footer>
+            </div>
+          </div>
+        </Transition.Child>
+      </Dialog>
+    </Transition.Root>
+  )
+}

--- a/app/components/EditorCommands.tsx
+++ b/app/components/EditorCommands.tsx
@@ -9,7 +9,7 @@ interface Props {
   onUndo: () => void;
   onRedo: () => void;
   onSave: () => void | Promise<void>;
-  onProof?: (sku: string) => void | Promise<void>;
+  onProof?: () => void | Promise<void>;
   saving: boolean;
   mode?: Mode;
 }
@@ -32,23 +32,14 @@ export default function EditorCommands({ onUndo, onRedo, onSave, onProof, saving
         {saving ? 'Saving…' : 'Save'}
       </button>
       {mode === 'staff' && onProof && (
-        <>
-          {[
-            ['greeting-card-giant', 'Giant'],
-            ['greeting-card-classic', 'Classic'],
-            ['greeting-card-mini', 'Mini'],
-          ].map(([sku, label]) => (
-            <button
-              key={sku}
-              type="button"
-              onClick={() => onProof(sku)}
-              className="flex items-center gap-1 px-3 py-2 rounded text-[--walty-teal] hover:bg-[--walty-teal]/10"
-            >
-              <Download className="w-5 h-5" />
-              {label}
-            </button>
-          ))}
-        </>
+        <button
+          type="button"
+          onClick={() => onProof()}
+          className="flex items-center gap-1 px-3 py-2 rounded text-[--walty-teal] hover:bg-[--walty-teal]/10"
+        >
+          <Download className="w-5 h-5" />
+          Proofs
+        </button>
       )}
     </div>
   );

--- a/app/components/EditorStore.ts
+++ b/app/components/EditorStore.ts
@@ -51,6 +51,9 @@ interface EditorState {
   pages: TemplatePage[]
   activePage: number
 
+  /* ---- global crop mode ---- */
+  isCropMode: boolean
+
   /* ---- Selfie drawer ---- */
   drawerState: DrawerState
   drawerImages: string[]
@@ -71,6 +74,7 @@ interface EditorState {
   setDrawerState: (s: DrawerState) => void
   setDrawerImgs:  (a: string[]) => void
   setProgress:    (n: number) => void
+  setCropMode:    (b: boolean) => void
 
     /* new — FabricCanvas pushes a whole page’s layer list */
   setPageLayers: (page: number, layers: EditorLayer[]) => void
@@ -93,6 +97,9 @@ export const useEditor = create<EditorState>((set, get) => ({
   drawerState: 'idle',
   drawerImages: [],
   drawerProgress: 0,
+
+  /* ---- crop mode ---- */
+  isCropMode: false,
 
   /* ───── history ───── */
   history: [],
@@ -143,6 +150,7 @@ export const useEditor = create<EditorState>((set, get) => ({
   setDrawerState: s   => set({ drawerState: s, drawerProgress: 0 }),
   setDrawerImgs : arr => set({ drawerImages: arr, choice: undefined }),
   setProgress   : n   => set({ drawerProgress: n }),
+  setCropMode   : b   => set({ isCropMode: b }),
 
     /* push whole layer arrays coming from FabricCanvas */
     setPageLayers : (pageIdx: number, layers: EditorLayer[]) =>

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -558,8 +558,8 @@ useEffect(() => {
     croppingRef.current = state
     onCroppingChange?.(state)
   })
-  cropToolRef.current = crop
-  ;(fc as any)._cropTool = crop
+  cropToolRef.current = crop;
+  ;(fc as any)._cropTool = crop;
   (fc as any)._syncLayers = () => syncLayersFromCanvas(fc, pageIdx);
 
   // double‑click on an <image> starts cropping

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -554,9 +554,12 @@ useEffect(() => {
 
   /* ── Crop‑tool wiring ────────────────────────────────────── */
   // create a reusable crop helper and keep it in a ref
-  const crop = new CropTool(fc, SCALE, SEL_COLOR);
-  cropToolRef.current = crop;
-  (fc as any)._cropTool = crop;
+  const crop = new CropTool(fc, SCALE, SEL_COLOR, state => {
+    croppingRef.current = state
+    onCroppingChange?.(state)
+  })
+  cropToolRef.current = crop
+  ;(fc as any)._cropTool = crop
   (fc as any)._syncLayers = () => syncLayersFromCanvas(fc, pageIdx);
 
   // double‑click on an <image> starts cropping

--- a/app/library/layerAdapters.ts
+++ b/app/library/layerAdapters.ts
@@ -17,10 +17,13 @@ const DEFAULT_SPEC: PrintSpec = {
   dpi         : 300,
 }
 
-const pageDims = (spec: PrintSpec = DEFAULT_SPEC) => ({
-  PAGE_W: Math.round((spec.trimWidthIn + spec.bleedIn * 2) * spec.dpi),
-  PAGE_H: Math.round((spec.trimHeightIn + spec.bleedIn * 2) * spec.dpi),
-})
+const pageDims = (spec?: PrintSpec | null) => {
+  const s = spec ?? DEFAULT_SPEC
+  return {
+    PAGE_W: Math.round((s.trimWidthIn + s.bleedIn * 2) * s.dpi),
+    PAGE_H: Math.round((s.trimHeightIn + s.bleedIn * 2) * s.dpi),
+  }
+}
 
 /* ───────── helpers ──────────────────────────────────────────────── */
 function isSanityRef(src:any): src is { _type:'image'; asset:{ _ref:string } } {

--- a/lib/CropTool.ts
+++ b/lib/CropTool.ts
@@ -14,6 +14,7 @@ export class CropTool {
   private fc      : fabric.Canvas
   private SCALE   : number
   private SEL     : string
+  private onChange?: (state: boolean) => void
   private img     : fabric.Image | null = null
   private frame   : fabric.Group | null = null
   private masks   : fabric.Rect[] = [];      // 4‑piece dim overlay
@@ -23,10 +24,12 @@ export class CropTool {
   /** clean‑up callbacks to run on `teardown()` */
   private cleanup: Array<() => void> = [];
 
-  constructor (fc: fabric.Canvas, scale: number, selColour: string) {
-    this.fc    = fc
-    this.SCALE = scale
-    this.SEL   = selColour
+  constructor (fc: fabric.Canvas, scale: number, selColour: string,
+               onChange?: (state: boolean) => void) {
+    this.fc      = fc
+    this.SCALE   = scale
+    this.SEL     = selColour
+    this.onChange= onChange
   }
 
   /* ─────────────── public API ──────────────────────────────────── */
@@ -38,6 +41,7 @@ export class CropTool {
     this.cleanup = [];
 
     this.isActive = true
+    this.onChange?.(true)
     this.img      = img
     // allow freeform scaling of the crop window
     const prevUniformScaling = this.fc.uniformScaling
@@ -741,6 +745,7 @@ export class CropTool {
     this.img      = null
     this.orig     = null
     this.isActive = false
+    this.onChange?.(false)
   }
 
   /* keep bitmap inside frame */

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "purge:assets": "tsx ./scripts/purge-assets.ts",
-    "purge:once": "tsx scripts/purgeTempAssets.ts"
+    "purge:once": "tsx scripts/purgeTempAssets.ts",
+    "migrate:printSpecs": "tsx scripts/migratePrintSpecs.ts"
   },
   "dependencies": {
     "@headlessui/react": "2.2.2",

--- a/sanity/schemaTypes/cardProduct.ts
+++ b/sanity/schemaTypes/cardProduct.ts
@@ -47,14 +47,29 @@ export default defineType({
     defineField({
       name: 'printSpec',
       title: 'Print specification',
-      type: 'printSpec',
+      type: 'reference',
+      to: [{ type: 'printSpec' }],
       validation: Rule => Rule.required(),
     }),
 
-    /* print specs – the editor can read these if you ever show guides
-       per product */
-    defineField({name:'trimWidthMm',  type:'number', title:'Trim width (mm)',  validation:(R)=>R.required()}),
-    defineField({name:'trimHeightMm', type:'number', title:'Trim height (mm)', validation:(R)=>R.required()}),
-    defineField({name:'pageCount',    type:'number', title:'Pages',            initialValue:4, validation:(R)=>R.required().integer().min(1).max(4)}),
+    /* toggle cropping guides for templates using this SKU */
+    defineField({
+      name: 'showSafeArea',
+      type: 'boolean',
+      title: 'Show safe-area overlay',
+      initialValue: true,
+      description: 'Display the safe-area guide when editing templates',
+      options: {layout: 'switch'},
+      validation: r => r.required(),
+    }),
+
+    defineField({
+      name: 'pageCount',
+      type: 'number',
+      title: 'Pages',
+      initialValue: 4,
+      validation: R => R.required().integer().min(1).max(4),
+    }),
   ],
+
 })

--- a/sanity/schemaTypes/cardTemplate.ts
+++ b/sanity/schemaTypes/cardTemplate.ts
@@ -120,6 +120,34 @@ export default defineType({
       validation: r => r.required(),
     }),
 
+    defineField({
+      name: 'previewSpec',
+      type: 'object',
+      title: 'Preview canvas',
+      group: 'basic',
+      fields: [
+        {
+          name: 'previewWidthPx',
+          type: 'number',
+          title: 'Width (px)',
+          initialValue: 420,
+          validation: r => r.required().positive(),
+        },
+        {
+          name: 'previewHeightPx',
+          type: 'number',
+          title: 'Height (px)',
+          initialValue: 580,
+          validation: r => r.required().positive(),
+        },
+        defineField({
+          name: 'maxMobileWidthPx',
+          type: 'number',
+          title: 'Max mobile width (px)',
+        }),
+      ],
+    }),
+
     /* —— Pages —————————————————————————— */
     defineField({
       name: 'pages',
@@ -229,13 +257,4 @@ export default defineType({
       of: [{type: 'reference', to: [{type: 'relation'}]}],
     }),
   ],
-
-  /* —— publish guard —————————————————— */
-  validation: Rule =>
-    Rule.custom((doc: any) => {
-      if (doc.isLive && (!doc.products || doc.products.length === 0)) {
-        return 'Cannot publish: add at least one product and keep “Visible in store?” ON'
-      }
-      return true
-    }),
 })

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -4,8 +4,9 @@
 
 import cardTemplate  from './cardTemplate'
 import cardProduct   from './cardProduct'
+import product       from './product'
 import productMockup from './productMockup'
-import page          from './page'
+import sitePage      from './sitePage'
 
 /* AI-related ---------------------------------------------------- */
 import aiPlaceholder from './aiPlaceholder'
@@ -27,17 +28,18 @@ import relation from './relation'   // ← RE-ADDED ✔
 export const schemaTypes = [
   /* documents */
   cardTemplate,
+  product,
   cardProduct,
   productMockup,
-  page,
+  sitePage,
   aiPlaceholder,
+  printSpec,
 
   /* objects */
   aiLayer,
   editableImage,
   editableText,
   heroSection,
-  printSpec,
 
   /* facets */
   occasion,

--- a/sanity/schemaTypes/printSpec.ts
+++ b/sanity/schemaTypes/printSpec.ts
@@ -2,7 +2,7 @@ import {defineType, defineField} from 'sanity'
 
 export default defineType({
   name: 'printSpec',
-  type: 'object',
+  type: 'document',
   title: 'Print specification',
   fields: [
     defineField({

--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -1,0 +1,34 @@
+import {defineType, defineField} from 'sanity'
+
+export default defineType({
+  name: 'product',
+  type: 'document',
+  title: 'Product',
+  fields: [
+    defineField({
+      name: 'title',
+      type: 'string',
+      title: 'Product name',
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'slug',
+      type: 'slug',
+      title: 'Slug',
+      options: { source: 'title', maxLength: 96 },
+      validation: r => r.required(),
+    }),
+    defineField({
+      name: 'description',
+      type: 'text',
+      title: 'Description',
+    }),
+    defineField({
+      name: 'variants',
+      type: 'array',
+      title: 'Variants',
+      of: [{ type: 'reference', to: [{ type: 'cardProduct' }] }],
+      validation: r => r.min(1),
+    }),
+  ],
+})

--- a/sanity/schemaTypes/sitePage.ts
+++ b/sanity/schemaTypes/sitePage.ts
@@ -1,7 +1,7 @@
 import {defineArrayMember, defineField, defineType} from 'sanity'
 
 export default defineType({
-  name: 'page',
+  name: 'sitePage',
   type: 'document',
   title: 'Site page',
   fields: [

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -29,15 +29,157 @@ export const structure: StructureResolver = (S: StructureBuilder) =>
   S.list()
     .title('Content')
     .items([
-      /* day-to-day documents -------------------------------------- */
+      /* ---------------------- Templates branch ------------------ */
       S.listItem()
-        .title('Card templates')
-        .schemaType('cardTemplate')
-        .child(cardTemplateList(S)),
+        .title('Templates')
+        .child(
+          S.list()
+            .title('Templates')
+            .items([
+              S.listItem()
+                .title('All templates')
+                .child(cardTemplateList(S)),
 
-      S.documentTypeListItem('cardProduct').title('Card products'),
+              S.listItem()
+                .title('By product type')
+                .child(
+                  S.list()
+                    .title('By product type')
+                    .items([
+                      S.listItem()
+                        .title('Greeting Cards')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Greeting Cards')
+                            .filter('_type == "cardTemplate" && templateType == "card"')
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Mugs')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Mugs')
+                            .filter('_type == "cardTemplate" && templateType == "mug"')
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Posters')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Posters')
+                            .filter('_type == "cardTemplate" && templateType == "poster"')
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                    ]),
+                ),
 
-      S.documentTypeListItem('page').title('Site pages'),
+              S.listItem()
+                .title('By format')
+                .child(
+                  S.list()
+                    .title('By format')
+                    .items([
+                      S.listItem()
+                        .title('Portrait')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Portrait')
+                            .filter(
+                              '_type == "cardTemplate" && previewSpec.previewHeightPx > previewSpec.previewWidthPx'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Landscape')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Landscape')
+                            .filter(
+                              '_type == "cardTemplate" && previewSpec.previewWidthPx > previewSpec.previewHeightPx'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Square')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Square')
+                            .filter(
+                              '_type == "cardTemplate" && previewSpec.previewWidthPx == previewSpec.previewHeightPx'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                    ]),
+                ),
+
+              S.listItem()
+                .title('By occasion')
+                .child(
+                  S.list()
+                    .title('By occasion')
+                    .items([
+                      S.listItem()
+                        .title('Birthday')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Birthday')
+                            .filter(
+                              '_type == "cardTemplate" && "birthday" in occasion[]->slug.current'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Wedding')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Wedding')
+                            .filter(
+                              '_type == "cardTemplate" && "wedding" in occasion[]->slug.current'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                      S.listItem()
+                        .title('Christmas')
+                        .child(
+                          S.documentTypeList('cardTemplate')
+                            .title('Christmas')
+                            .filter(
+                              '_type == "cardTemplate" && "christmas" in occasion[]->slug.current'
+                            )
+                            .child((id) => cardTemplateNode(S, id)),
+                        ),
+                    ]),
+                ),
+
+              S.listItem()
+                .title('Drafts / Needs review')
+                .child(
+                  S.documentTypeList('cardTemplate')
+                    .title('Drafts / Needs review')
+                    .filter(
+                      '_type == "cardTemplate" && (!isLive || _id in path("drafts.**"))'
+                    )
+                    .child((id) => cardTemplateNode(S, id)),
+                ),
+            ])
+        ),
+
+      S.divider(),
+
+      /* ---------------------- Commerce branch ------------------- */
+      S.listItem()
+        .title('Commerce')
+        .child(
+          S.list()
+            .title('Commerce')
+            .items([
+              S.documentTypeListItem('product').title('Products'),
+              S.documentTypeListItem('cardProduct').title('Variants'),
+              S.documentTypeListItem('printSpec').title('Print specs'),
+            ]),
+        ),
+
+      S.documentTypeListItem('sitePage').title('Site pages'),
 
       /* look-ups & presets tucked into a drawer ------------------- */
       S.listItem()

--- a/scripts/migratePrintSpecs.ts
+++ b/scripts/migratePrintSpecs.ts
@@ -1,0 +1,64 @@
+import 'dotenv/config'
+import {createClient} from '@sanity/client'
+import {nanoid} from 'nanoid'
+
+const sanity = createClient({
+  projectId : process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset   : process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  apiVersion: '2025-02-19',
+  token     : process.env.SANITY_SERVICE_TOKEN,
+  useCdn    : false,
+})
+
+async function run() {
+  const products = await sanity.fetch<{
+    _id: string
+    printSpec?: any
+    trimWidthMm?: number
+    trimHeightMm?: number
+  }[]>(`*[_type=="cardProduct"]{_id, printSpec, trimWidthMm, trimHeightMm}`)
+
+  for (const p of products) {
+    if (p.printSpec?._ref) continue
+    const spec = p.printSpec ?? (p.trimWidthMm && p.trimHeightMm ? {
+      trimWidthIn : p.trimWidthMm / 25.4,
+      trimHeightIn: p.trimHeightMm / 25.4,
+      bleedIn     : 0.125,
+      dpi         : 300,
+    } : null)
+    if (!spec) continue
+
+    const q = `*[_type=="printSpec" && trimWidthIn==$w && trimHeightIn==$h && bleedIn==$b && dpi==$d][0]._id`
+    let specId = await sanity.fetch<string|null>(q, {
+      w: spec.trimWidthIn,
+      h: spec.trimHeightIn,
+      b: spec.bleedIn,
+      d: spec.dpi,
+    })
+
+    if (!specId) {
+      specId = `spec-${nanoid()}`
+      await sanity.create({ _id: specId, _type: 'printSpec', ...spec })
+    }
+
+    await sanity
+      .patch(p._id)
+      .set({ printSpec: { _type: 'reference', _ref: specId } })
+      .unset([
+        'trimWidthMm',
+        'trimHeightMm',
+        'printSpec.trimWidthIn',
+        'printSpec.trimHeightIn',
+        'printSpec.bleedIn',
+        'printSpec.dpi',
+      ])
+      .commit()
+
+    console.log(`✔ migrated ${p._id} → ${specId}`)
+  }
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- introduce `CropDrawer` for ratio presets and apply/cancel actions
- extend `EditorStore` with `isCropMode` flag and setter
- wire up `CardEditor` to toggle crop mode, hide UI, and call `CropDrawer`

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684dedbc84dc8323811ef31ea2ac2f41