### PR TITLE
Fetch edgeBleed in template loader

### DIFF
--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -61,6 +61,7 @@ export async function getTemplatePages(
       showSafeArea
     },
     pages[]{
+      edgeBleed,
       layers[]{
         ...,                       // keep every native field
         // if this layer has a reference called “source”, pull it in-line:


### PR DESCRIPTION
## Summary
- extend Sanity GROQ query in `getTemplatePages` to fetch each page's `edgeBleed`

## Testing
- `npm run lint` *(fails: React Hooks rules)*

------
https://chatgpt.com/codex/tasks/task_e_684ed34d1bec8323ab9adfd43e27427e