### PR TITLE
Implement card spread helper

### DIFF
--- a/app/api/proof/buildSpread.ts
+++ b/app/api/proof/buildSpread.ts
@@ -1,0 +1,69 @@
+import { createCanvas, loadImage } from 'canvas'
+
+export interface Panel {
+  name: string
+  order: number
+}
+
+export interface SpreadLayout {
+  spreadWidth: number
+  spreadHeight: number
+  panels: Panel[]
+}
+
+export interface BuildSpreadSpec {
+  dpi: number
+  spreadLayout: SpreadLayout
+}
+
+export interface SpreadResult {
+  blob: Buffer
+  filename: string
+  mime: string
+}
+
+/**
+ * Assemble the four page buffers into a full spread.
+ */
+export async function buildSpread(
+  pages: Buffer[],
+  spec: BuildSpreadSpec,
+  templateSlug: string,
+  sku: string,
+): Promise<SpreadResult> {
+  const { spreadLayout, dpi } = spec
+  const spreadPxW = Math.round(spreadLayout.spreadWidth * dpi)
+  const spreadPxH = Math.round(spreadLayout.spreadHeight * dpi)
+
+  console.log(`▶ buildSpread ${spreadPxW}×${spreadPxH}`)
+
+  const canvas = createCanvas(spreadPxW, spreadPxH)
+  const ctx = canvas.getContext('2d')
+  ctx.clearRect(0, 0, spreadPxW, spreadPxH)
+
+  const panels = [...spreadLayout.panels].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  const pageW = Math.floor(spreadPxW / 2)
+  const pageH = Math.floor(spreadPxH / 2)
+
+  const posMap: Record<string, { x: number; y: number }> = {
+    'Outer rear' : { x: 0,      y: 0 },
+    'Outer front': { x: pageW,  y: 0 },
+    'Inside back': { x: 0,      y: pageH },
+    'Inside front':{ x: pageW,  y: pageH },
+  }
+
+  for (let i = 0; i < panels.length && i < pages.length; i++) {
+    const panel = panels[i]
+    const buf = pages[i]
+    const pos = posMap[panel.name]
+    if (!buf || !pos) continue
+    const img = await loadImage(buf)
+    ctx.drawImage(img, pos.x, pos.y, pageW, pageH)
+    console.log(`  paste ${panel.name} → [${pos.x}, ${pos.y}]`)
+  }
+
+  const blob = canvas.toBuffer('image/jpeg', { quality: 0.95 })
+  const filename = `${templateSlug}-${sku}.jpg`
+
+  return { blob, filename, mime: 'image/jpeg' }
+}

--- a/app/api/proof/buildSpread.ts
+++ b/app/api/proof/buildSpread.ts
@@ -14,6 +14,9 @@ export interface SpreadLayout {
 export interface BuildSpreadSpec {
   dpi: number
   spreadLayout: SpreadLayout
+  trimWidthIn: number
+  trimHeightIn: number
+  bleedIn: number
 }
 
 export interface SpreadResult {
@@ -31,37 +34,68 @@ export async function buildSpread(
   templateSlug: string,
   sku: string,
 ): Promise<SpreadResult> {
-  const { spreadLayout, dpi } = spec
-  const spreadPxW = Math.round(spreadLayout.spreadWidth * dpi)
-  const spreadPxH = Math.round(spreadLayout.spreadHeight * dpi)
+  const { spreadLayout, dpi, trimWidthIn, trimHeightIn, bleedIn } = spec
 
-  console.log(`▶ buildSpread ${spreadPxW}×${spreadPxH}`)
+  const px = (n: number) => Math.round(n * dpi)
+  const bleedPx = px(bleedIn)
 
-  const pageW = Math.floor(spreadPxW / 2)
-  const pageH = Math.floor(spreadPxH / 2)
+  const baseW = px(trimWidthIn + bleedIn * 2)
+  const baseH = px(trimHeightIn + bleedIn * 2)
+
+  const panels = [...spreadLayout.panels].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+
+  const crops: Buffer[] = []
+  let pageWpx = 0
+  let pageHpx = 0
+
+  for (let i = 0; i < panels.length && i < pages.length; i++) {
+    const panel = panels[i]
+    const buf = pages[i]
+    if (!buf) continue
+    const bleed = panel.bleed ?? {}
+    const cropL = bleed.left === false ? bleedPx : 0
+    const cropR = bleed.right === false ? bleedPx : 0
+    const cropT = bleed.top === false ? bleedPx : 0
+    const cropB = bleed.bottom === false ? bleedPx : 0
+    const width = baseW - cropL - cropR
+    const height = baseH - cropT - cropB
+
+    const outBuf = await sharp(buf)
+      .extract({ left: cropL, top: cropT, width, height })
+      .toBuffer()
+
+    console.log(`  extract ${panel.name}: ${width}×${height}`)
+
+    crops[i] = outBuf
+    if (!pageWpx) pageWpx = width
+    if (!pageHpx) pageHpx = height
+  }
+
+  const canvasW = pageWpx * 2
+  const canvasH = pageHpx * 2
+
+  console.log(`▶ buildSpread ${canvasW}×${canvasH}`)
 
   let out = sharp({
     create: {
-      width: spreadPxW,
-      height: spreadPxH,
+      width: canvasW,
+      height: canvasH,
       channels: 4,
       background: { r: 0, g: 0, b: 0, alpha: 0 },
     },
   }).toColourspace('srgb')
 
-  const panels = [...spreadLayout.panels].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-
   const posMap: Record<string, { left: number; top: number }> = {
-    'Outer rear':   { left: 0,     top: 0 },
-    'Outer front':  { left: pageW, top: 0 },
-    'Inside back':  { left: 0,     top: pageH },
-    'Inside front': { left: pageW, top: pageH },
+    'Outer rear':   { left: 0,       top: 0 },
+    'Outer front':  { left: pageWpx, top: 0 },
+    'Inside back':  { left: 0,       top: pageHpx },
+    'Inside front': { left: pageWpx, top: pageHpx },
   }
 
   const comps: sharp.OverlayOptions[] = []
-  for (let i = 0; i < panels.length && i < pages.length; i++) {
+  for (let i = 0; i < panels.length && i < crops.length; i++) {
     const panel = panels[i]
-    const buf = pages[i]
+    const buf = crops[i]
     const pos = posMap[panel.name]
     if (!buf || !pos) continue
     comps.push({ input: buf, left: pos.left, top: pos.top })

--- a/app/api/proof/route.ts
+++ b/app/api/proof/route.ts
@@ -120,7 +120,13 @@ export async function POST(req: NextRequest) {
     if (Array.isArray(layout.panels) && layout.panels.length === 4) {
       const { blob, filename: fName } = await buildSpread(
         pageBuffers,
-        { dpi: finalSpec.dpi, spreadLayout: layout },
+        {
+          dpi: finalSpec.dpi,
+          spreadLayout: layout,
+          trimWidthIn: finalSpec.trimWidthIn,
+          trimHeightIn: finalSpec.trimHeightIn,
+          bleedIn: finalSpec.bleedIn,
+        },
         esc(id),
         sku ?? 'proof',
       )


### PR DESCRIPTION
## Summary
- add buildSpread utility to compose full greeting card spread
- call buildSpread from proof route when spec defines a 4‑panel layout

## Testing
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_684efca45cac8323b752c86a8c857d97