### PR TITLE
Link print spec panels to pages

### DIFF
--- a/app/api/proof/buildSpread.ts
+++ b/app/api/proof/buildSpread.ts
@@ -2,6 +2,7 @@ import sharp from 'sharp'
 
 export interface Panel {
   name: string
+  page: string
   order: number
   bleed?: {
     top?: boolean
@@ -35,7 +36,7 @@ export interface SpreadResult {
  * Assemble the four page buffers into a full spread.
  */
 export async function buildSpread(
-  pages: Buffer[],
+  pageMap: Record<string, Buffer>,
   spec: BuildSpreadSpec,
   templateSlug: string,
   sku: string,
@@ -58,9 +59,9 @@ export async function buildSpread(
 
   const crops: Buffer[] = []
 
-  for (let i = 0; i < panels.length && i < pages.length; i++) {
+  for (let i = 0; i < panels.length; i++) {
     const panel = panels[i]
-    const buf = pages[i]
+    const buf = pageMap[panel.page || panel.name]
     if (!buf) continue
     const bleed = panel.bleed ?? {}
     const cropL = bleed.left === false ? bleedPx : 0

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -28,6 +28,7 @@ export interface PrintSpec {
     spreadHeight: number
     panels: {
       name: string
+      page: string
       order: number
       bleed?: {
         top?: boolean

--- a/sanity/schemaTypes/printSpec.ts
+++ b/sanity/schemaTypes/printSpec.ts
@@ -53,16 +53,31 @@ export default defineType({
           type: 'array',
           title: 'Panels (placement order)',
           initialValue: [
-            { name: 'Outer rear',  order: 0, bleed: { top: true, right: true, bottom: true, left: true } },
-            { name: 'Outer front', order: 1, bleed: { top: true, right: true, bottom: true, left: true } },
-            { name: 'Inside front', order: 2, bleed: { top: true, right: true, bottom: true, left: true } },
-            { name: 'Inside back', order: 3, bleed: { top: true, right: true, bottom: true, left: true } },
+            { name: 'Outer rear',  page: 'back',    order: 0, bleed: { top: true, right: true, bottom: true, left: true } },
+            { name: 'Outer front', page: 'front',   order: 1, bleed: { top: true, right: true, bottom: true, left: true } },
+            { name: 'Inside front', page: 'inner-R', order: 2, bleed: { top: true, right: true, bottom: true, left: true } },
+            { name: 'Inside back', page: 'inner-L',  order: 3, bleed: { top: true, right: true, bottom: true, left: true } },
           ],
           of: [
             defineArrayMember({
               type: 'object',
               fields: [
-                defineField({ name: 'name',  type: 'string', title: 'Page name' }),
+                defineField({ name: 'name',  type: 'string', title: 'Panel name' }),
+                defineField({
+                  name: 'page',
+                  type: 'string',
+                  title: 'Card page',
+                  options: {
+                    list: [
+                      { title: 'Front cover', value: 'front' },
+                      { title: 'Inner left',  value: 'inner-L' },
+                      { title: 'Inner right', value: 'inner-R' },
+                      { title: 'Back cover',  value: 'back' },
+                    ],
+                    layout: 'dropdown',
+                  },
+                  validation: r => r.required(),
+                }),
                 defineField({
                   name: 'order',
                   type: 'number',


### PR DESCRIPTION
## Summary
- assign template pages to print spec panels
- add page field to PrintSpec types
- build proofs using selected pages

## Testing
- `npm run lint` *(fails: React hook rule violations)*
- `npm run build` *(fails: network fetch for Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684f31a96c788323a29f7b3503463aa6