### PR TITLE
Add checkout UI skeleton

### DIFF
--- a/app/checkout/AddressDrawer.tsx
+++ b/app/checkout/AddressDrawer.tsx
@@ -1,0 +1,108 @@
+"use client";
+import { useState } from 'react';
+import { Address } from './CheckoutClient';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSave: (addr: Address) => void;
+}
+
+export default function AddressDrawer({ open, onClose, onSave }: Props) {
+  const [name, setName] = useState('');
+  const [line1, setLine1] = useState('');
+  const [city, setCity] = useState('');
+  const [postcode, setPostcode] = useState('');
+  const [country, setCountry] = useState('UK');
+
+  const reset = () => {
+    setName('');
+    setLine1('');
+    setCity('');
+    setPostcode('');
+    setCountry('UK');
+  };
+
+  const handleSave = () => {
+    const id = Date.now().toString();
+    onSave({ id, name, line1, city, postcode, country });
+    reset();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div className="absolute inset-y-0 right-0 w-full sm:max-w-md bg-white shadow-xl p-6 overflow-y-auto">
+        <h3 className="font-display text-lg text-walty-teal mb-4">Add Address</h3>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSave();
+          }}
+          className="space-y-4"
+        >
+          <div>
+            <label className="block text-sm mb-1" htmlFor="name">Name</label>
+            <input
+              id="name"
+              className="w-full border rounded p-2 text-sm"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1" htmlFor="line1">Line 1</label>
+            <input
+              id="line1"
+              className="w-full border rounded p-2 text-sm"
+              value={line1}
+              onChange={(e) => setLine1(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1" htmlFor="city">City</label>
+            <input
+              id="city"
+              className="w-full border rounded p-2 text-sm"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1" htmlFor="postcode">Postcode</label>
+            <input
+              id="postcode"
+              className="w-full border rounded p-2 text-sm"
+              value={postcode}
+              onChange={(e) => setPostcode(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1" htmlFor="country">Country</label>
+            <select
+              id="country"
+              className="w-full border rounded p-2 text-sm"
+              value={country}
+              onChange={(e) => setCountry(e.target.value)}
+            >
+              <option value="UK">UK</option>
+              <option value="US">US</option>
+            </select>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 rounded-md border">Cancel</button>
+            <button type="submit" className="rounded-md bg-walty-orange text-walty-cream px-4 py-2 hover:bg-orange-600 transition">
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/checkout/Basket.tsx
+++ b/app/checkout/Basket.tsx
@@ -1,11 +1,14 @@
 "use client";
 import Image from 'next/image';
+import { useState } from 'react';
 import { Address, CartItem } from './CheckoutClient';
+import { CARD_SIZES } from './sizeOptions';
 
 interface BasketProps {
   items: CartItem[];
   addresses: Address[];
   onQtyChange: (id: string, qty: number) => void;
+  onVariantChange: (id: string, variant: string) => void;
   onAddressChange: (id: string, addressId: string) => void;
   onAddNew: (itemId: string) => void;
 }
@@ -14,12 +17,14 @@ export default function Basket({
   items,
   addresses,
   onQtyChange,
+  onVariantChange,
   onAddressChange,
   onAddNew,
 }: BasketProps) {
+  const [openId, setOpenId] = useState<string | null>(null);
   return (
     <div className="space-y-6">
-      <h2 className="font-display text-xl text-walty-teal">Your Basket</h2>
+      <h2 className="font-recoleta text-xl text-walty-teal">Your Basket</h2>
       {items.map((item) => (
         <div key={item.id} className="flex gap-4 items-start bg-white p-4 rounded-md shadow-card">
           <div className="w-20 h-28 flex-shrink-0 overflow-hidden rounded-md bg-gray-100">
@@ -29,8 +34,53 @@ export default function Basket({
             <div className="font-medium text-walty-teal">{item.title}</div>
             <div className="text-sm text-gray-600">SKU: {item.sku}</div>
             <div className="text-sm text-gray-600">£{item.price.toFixed(2)} each</div>
+            <div className="relative mt-2">
+              <label className="block text-sm font-recoleta text-walty-teal mb-1">Size</label>
+              {(() => {
+                const selected = CARD_SIZES.find((s) => s.id === item.variant) || CARD_SIZES[0];
+                return (
+                  <div className="relative inline-block">
+                    <button
+                      type="button"
+                      onClick={() => setOpenId(openId === item.id ? null : item.id)}
+                      className="flex items-center justify-between gap-2 bg-walty-cream border border-walty-teal text-walty-teal rounded-md px-3 py-1 min-w-[180px]"
+                    >
+                      <span className="flex items-center gap-1">
+                        <selected.Icon className="w-4 h-4" />
+                        {selected.label}
+                      </span>
+                      <span className="font-sans">£{selected.price.toFixed(2)}</span>
+                    </button>
+                    {openId === item.id && (
+                      <ul className="absolute z-10 mt-1 w-full rounded-md border border-walty-teal bg-walty-cream shadow-card">
+                        {CARD_SIZES.map((opt) => (
+                          <li key={opt.id}>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                onVariantChange(item.id, opt.id);
+                                setOpenId(null);
+                              }}
+                              className={`flex w-full items-center justify-between gap-2 px-3 py-2 hover:bg-walty-orange/20 ${
+                                opt.id === item.variant ? 'bg-walty-orange/20' : ''
+                              }`}
+                            >
+                              <span className="flex items-center gap-1 font-recoleta text-walty-teal">
+                                <opt.Icon className="w-4 h-4" />
+                                {opt.label}
+                              </span>
+                              <span className="font-sans text-walty-teal">£{opt.price.toFixed(2)}</span>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                );
+              })()}
+            </div>
             <div className="flex items-center gap-2 mt-2">
-              <label className="text-sm">Qty</label>
+              <label className="text-sm font-recoleta text-walty-teal">Qty</label>
               <input
                 type="number"
                 min={1}
@@ -40,7 +90,7 @@ export default function Basket({
               />
             </div>
             <div className="mt-2">
-              <label className="block text-sm mb-1">Ship to</label>
+              <label className="block text-sm font-recoleta text-walty-teal mb-1">Ship to</label>
               <select
                 value={item.addressId || ''}
                 onChange={(e) => {

--- a/app/checkout/Basket.tsx
+++ b/app/checkout/Basket.tsx
@@ -1,0 +1,66 @@
+"use client";
+import Image from 'next/image';
+import { Address, CartItem } from './CheckoutClient';
+
+interface BasketProps {
+  items: CartItem[];
+  addresses: Address[];
+  onQtyChange: (id: string, qty: number) => void;
+  onAddressChange: (id: string, addressId: string) => void;
+  onAddNew: (itemId: string) => void;
+}
+
+export default function Basket({
+  items,
+  addresses,
+  onQtyChange,
+  onAddressChange,
+  onAddNew,
+}: BasketProps) {
+  return (
+    <div className="space-y-6">
+      <h2 className="font-display text-xl text-walty-teal">Your Basket</h2>
+      {items.map((item) => (
+        <div key={item.id} className="flex gap-4 items-start bg-white p-4 rounded-md shadow-card">
+          <div className="w-20 h-28 flex-shrink-0 overflow-hidden rounded-md bg-gray-100">
+            <Image src={item.coverUrl} alt="" width={80} height={112} className="object-cover w-full h-full" />
+          </div>
+          <div className="flex-1 space-y-2">
+            <div className="font-medium text-walty-teal">{item.title}</div>
+            <div className="text-sm text-gray-600">SKU: {item.sku}</div>
+            <div className="text-sm text-gray-600">£{item.price.toFixed(2)} each</div>
+            <div className="flex items-center gap-2 mt-2">
+              <label className="text-sm">Qty</label>
+              <input
+                type="number"
+                min={1}
+                value={item.qty}
+                onChange={(e) => onQtyChange(item.id, Math.max(1, Number(e.target.value)))}
+                className="w-16 border rounded p-1 text-sm"
+              />
+            </div>
+            <div className="mt-2">
+              <label className="block text-sm mb-1">Ship to</label>
+              <select
+                value={item.addressId || ''}
+                onChange={(e) => {
+                  if (e.target.value === 'new') onAddNew(item.id);
+                  else onAddressChange(item.id, e.target.value);
+                }}
+                className="w-full border rounded p-2 text-sm"
+              >
+                <option value="">Select address...</option>
+                {addresses.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.name} – {a.city}
+                  </option>
+                ))}
+                <option value="new">Add new address…</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/checkout/CheckoutClient.tsx
+++ b/app/checkout/CheckoutClient.tsx
@@ -1,0 +1,137 @@
+"use client";
+import { useState } from 'react';
+import Basket from './Basket';
+import AddressDrawer from './AddressDrawer';
+import Summary from './Summary';
+import PaymentPlaceholder from './PaymentPlaceholder';
+
+export interface CartItem {
+  id: string;
+  coverUrl: string;
+  title: string;
+  sku: string;
+  qty: number;
+  price: number;
+  addressId?: string;
+}
+
+export interface Address {
+  id: string;
+  name: string;
+  line1: string;
+  city: string;
+  postcode: string;
+  country: string;
+}
+
+export default function CheckoutClient({
+  initialItems,
+  initialAddresses,
+}: {
+  initialItems: CartItem[];
+  initialAddresses: Address[];
+}) {
+  const [cartItems, setCartItems] = useState<CartItem[]>(initialItems);
+  const [addresses, setAddresses] = useState<Address[]>(initialAddresses);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [activeItemId, setActiveItemId] = useState<string | null>(null);
+  const [paymentComplete, setPaymentComplete] = useState(false);
+
+  const openDrawer = (itemId: string) => {
+    setActiveItemId(itemId);
+    setDrawerOpen(true);
+  };
+
+  const handleSaveAddress = (addr: Address) => {
+    setAddresses((prev) => [...prev, addr]);
+    if (activeItemId) {
+      setCartItems((prev) =>
+        prev.map((it) =>
+          it.id === activeItemId ? { ...it, addressId: addr.id } : it,
+        ),
+      );
+    }
+    setDrawerOpen(false);
+  };
+
+  const updateQty = (id: string, qty: number) => {
+    setCartItems((prev) => prev.map((it) => (it.id === id ? { ...it, qty } : it)));
+  };
+
+  const updateItemAddress = (id: string, addressId: string) => {
+    setCartItems((prev) =>
+      prev.map((it) => (it.id === id ? { ...it, addressId } : it)),
+    );
+  };
+
+  const subtotal = cartItems.reduce((sum, it) => sum + it.qty * it.price, 0);
+  const shipping = 0; // TODO: replace with API calculation
+  const vat = 0; // TODO: replace with API calculation
+  const total = subtotal + shipping + vat;
+
+  const placeOrder = () => {
+    console.log({ cartItems, addresses, totals: { subtotal, shipping, vat, total } });
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8 font-sans">
+      {/* Progress bar */}
+      <div className="flex items-center mb-6">
+        {['Basket', 'Payment', 'Review'].map((step, i) => (
+          <div key={step} className="flex items-center flex-1">
+            <div
+              className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
+                i === 0 ? 'bg-walty-orange text-walty-cream' : 'bg-gray-300 text-gray-600'
+              }`}
+            >
+              {i + 1}
+            </div>
+            <span className="ml-2 text-sm">{step}</span>
+            {i < 2 && <div className="flex-1 h-px bg-gray-300 mx-2" />}
+          </div>
+        ))}
+      </div>
+
+      <div className="lg:flex lg:items-start lg:gap-8">
+        <div className="lg:w-2/3">
+          <Basket
+            items={cartItems}
+            addresses={addresses}
+            onQtyChange={updateQty}
+            onAddressChange={updateItemAddress}
+            onAddNew={openDrawer}
+          />
+        </div>
+        <div className="lg:w-1/3 lg:sticky lg:top-4 mt-8 lg:mt-0">
+          <Summary subtotal={subtotal} shipping={shipping} vat={vat} total={total} />
+          <a href="#payment" className="block mt-4">
+            <button className="w-full rounded-md bg-walty-orange text-walty-cream px-4 py-2 hover:bg-orange-600 transition">
+              Continue to payment
+            </button>
+          </a>
+        </div>
+      </div>
+
+      {/* Payment */}
+      <div id="payment" className="mt-12">
+        <PaymentPlaceholder checked={paymentComplete} onCheck={setPaymentComplete} />
+      </div>
+
+      <div className="mt-6 text-center">
+        <button
+          className="rounded-md bg-walty-orange text-walty-cream px-6 py-3 hover:bg-orange-600 transition disabled:opacity-50"
+          disabled={!paymentComplete}
+          onClick={placeOrder}
+        >
+          Place order
+        </button>
+      </div>
+
+      <AddressDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        onSave={handleSaveAddress}
+      />
+    </div>
+  );
+}

--- a/app/checkout/CheckoutClient.tsx
+++ b/app/checkout/CheckoutClient.tsx
@@ -4,12 +4,14 @@ import Basket from './Basket';
 import AddressDrawer from './AddressDrawer';
 import Summary from './Summary';
 import PaymentPlaceholder from './PaymentPlaceholder';
+import { CARD_SIZES } from './sizeOptions';
 
 export interface CartItem {
   id: string;
   coverUrl: string;
   title: string;
   sku: string;
+  variant: string;
   qty: number;
   price: number;
   addressId?: string;
@@ -58,6 +60,16 @@ export default function CheckoutClient({
     setCartItems((prev) => prev.map((it) => (it.id === id ? { ...it, qty } : it)));
   };
 
+  const updateVariant = (id: string, variant: string) => {
+    const size = CARD_SIZES.find((s) => s.id === variant);
+    if (!size) return;
+    setCartItems((prev) =>
+      prev.map((it) =>
+        it.id === id ? { ...it, variant, price: size.price } : it,
+      ),
+    );
+  };
+
   const updateItemAddress = (id: string, addressId: string) => {
     setCartItems((prev) =>
       prev.map((it) => (it.id === id ? { ...it, addressId } : it)),
@@ -99,6 +111,7 @@ export default function CheckoutClient({
             addresses={addresses}
             onQtyChange={updateQty}
             onAddressChange={updateItemAddress}
+            onVariantChange={updateVariant}
             onAddNew={openDrawer}
           />
         </div>

--- a/app/checkout/PaymentPlaceholder.tsx
+++ b/app/checkout/PaymentPlaceholder.tsx
@@ -1,0 +1,20 @@
+"use client";
+interface Props {
+  checked: boolean;
+  onCheck: (c: boolean) => void;
+}
+
+export default function PaymentPlaceholder({ checked, onCheck }: Props) {
+  return (
+    <div className="border rounded-md p-6 bg-white shadow-card space-y-4">
+      <h3 className="font-display text-lg text-walty-teal">Card details</h3>
+      <div className="h-40 border border-dashed flex items-center justify-center rounded-md">
+        <span className="text-gray-500 text-sm">Stripe PaymentElement goes here later</span>
+      </div>
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={checked} onChange={(e) => onCheck(e.target.checked)} />
+        Card details entered
+      </label>
+    </div>
+  );
+}

--- a/app/checkout/Summary.tsx
+++ b/app/checkout/Summary.tsx
@@ -1,0 +1,31 @@
+"use client";
+interface Props {
+  subtotal: number;
+  shipping: number;
+  vat: number;
+  total: number;
+}
+
+export default function Summary({ subtotal, shipping, vat, total }: Props) {
+  return (
+    <div className="bg-white p-4 rounded-md shadow-card space-y-2">
+      <h3 className="font-display text-lg text-walty-teal mb-2">Order Summary</h3>
+      <div className="flex justify-between text-sm">
+        <span>Subtotal</span>
+        <span>£{subtotal.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between text-sm">
+        <span>Shipping</span>
+        <span>£{shipping.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between text-sm">
+        <span>VAT</span>
+        <span>£{vat.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between font-semibold border-t pt-2">
+        <span>Total</span>
+        <span>£{total.toFixed(2)}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,0 +1,44 @@
+import CheckoutClient from './CheckoutClient';
+
+export default function CheckoutPage() {
+  // Seed dummy cart items and addresses
+  const items = [
+    {
+      id: '1',
+      coverUrl: '/templates/daisy/daisy-front-cover.jpg',
+      title: 'Birthday Card',
+      sku: 'BDY-001',
+      qty: 1,
+      price: 3.5,
+    },
+    {
+      id: '2',
+      coverUrl: '/templates/daisy/daisy-inner-left.jpg',
+      title: 'Thank You Card',
+      sku: 'THX-002',
+      qty: 2,
+      price: 3.0,
+    },
+  ];
+
+  const addresses = [
+    {
+      id: 'a1',
+      name: 'Alice Example',
+      line1: '1 Apple Way',
+      city: 'London',
+      postcode: 'N1 1AA',
+      country: 'UK',
+    },
+    {
+      id: 'a2',
+      name: 'Bob Example',
+      line1: '2 Orange Road',
+      city: 'Bristol',
+      postcode: 'BS1 2BB',
+      country: 'UK',
+    },
+  ];
+
+  return <CheckoutClient initialItems={items} initialAddresses={addresses} />;
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -8,6 +8,7 @@ export default function CheckoutPage() {
       coverUrl: '/templates/daisy/daisy-front-cover.jpg',
       title: 'Birthday Card',
       sku: 'BDY-001',
+      variant: 'classic',
       qty: 1,
       price: 3.5,
     },
@@ -16,8 +17,9 @@ export default function CheckoutPage() {
       coverUrl: '/templates/daisy/daisy-inner-left.jpg',
       title: 'Thank You Card',
       sku: 'THX-002',
+      variant: 'mini',
       qty: 2,
-      price: 3.0,
+      price: 2.5,
     },
   ];
 

--- a/app/checkout/sizeOptions.ts
+++ b/app/checkout/sizeOptions.ts
@@ -1,0 +1,15 @@
+import { Square, RectangleHorizontal, Expand } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+export interface CardSize {
+  id: string
+  label: string
+  price: number
+  Icon: LucideIcon
+}
+
+export const CARD_SIZES: CardSize[] = [
+  { id: 'mini', label: 'Mini Card', price: 2.5, Icon: Square },
+  { id: 'classic', label: 'Classic Card', price: 3.5, Icon: RectangleHorizontal },
+  { id: 'giant', label: 'Giant Card', price: 5, Icon: Expand },
+]

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { Dialog, Transition } from '@headlessui/react'
+import { Fragment, useState } from 'react'
+import { Check } from 'lucide-react'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onAdd: (sku: string) => void
+}
+
+const OPTIONS = [
+  { label: 'Single card', sku: 'single' },
+  { label: 'Pack of 5', sku: 'pack5' },
+  { label: 'Pack of 10', sku: 'pack10' },
+  { label: 'Pack of 20', sku: 'pack20' },
+]
+
+export default function AddToBasketDialog({ open, onClose, onAdd }: Props) {
+  const [choice, setChoice] = useState<string | null>(null)
+
+  const handleAdd = () => {
+    if (choice) {
+      onAdd(choice)
+    }
+  }
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="fixed inset-0 z-50 flex items-center justify-center" onClose={onClose}>
+        <div className="fixed inset-0 bg-black/60" aria-hidden="true" />
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0 scale-95"
+          enterTo="opacity-100 scale-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100 scale-100"
+          leaveTo="opacity-0 scale-95"
+        >
+          <div className="bg-white rounded shadow-lg w-[min(90vw,420px)] p-6 space-y-6">
+            <h2 className="font-domine text-xl text-[--walty-teal]">Choose an option</h2>
+            <ul className="space-y-2">
+              {OPTIONS.map((opt) => (
+                <li key={opt.sku}>
+                  <button
+                    onClick={() => setChoice(opt.sku)}
+                    className={`w-full flex items-center justify-between border rounded-md p-3 ${choice === opt.sku ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
+                  >
+                    <span>{opt.label}</span>
+                    {choice === opt.sku && <Check className="text-[--walty-orange]" size={20} />}
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <div className="flex justify-end gap-4 pt-2">
+              <button onClick={onClose} className="rounded-md border border-gray-300 px-4 py-2">Back to editor</button>
+              <button
+                onClick={handleAdd}
+                disabled={!choice}
+                className={`rounded-md px-4 py-2 font-semibold text-white ${choice ? 'bg-[--walty-orange] hover:bg-orange-600' : 'bg-gray-300 cursor-not-allowed'}`}
+              >
+                Add to basket
+              </button>
+            </div>
+          </div>
+        </Transition.Child>
+      </Dialog>
+    </Transition.Root>
+  )
+}

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -3,11 +3,12 @@
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment, useState } from 'react'
 import { Check } from 'lucide-react'
+import { useBasket } from '@/lib/useBasket'
 
 interface Props {
   open: boolean
   onClose: () => void
-  onAdd: (sku: string) => void
+  onAdd?: (sku: string) => void
 }
 
 const OPTIONS = [
@@ -19,10 +20,14 @@ const OPTIONS = [
 
 export default function AddToBasketDialog({ open, onClose, onAdd }: Props) {
   const [choice, setChoice] = useState<string | null>(null)
+  const { addItem } = useBasket()
 
   const handleAdd = () => {
     if (choice) {
-      onAdd(choice)
+      addItem(choice)
+      onAdd?.(choice)
+      onClose()
+      setChoice(null)
     }
   }
 

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -28,7 +28,11 @@ export default function AddToBasketDialog({ open, onClose, onAdd }: Props) {
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="fixed inset-0 z-50 flex items-center justify-center" onClose={onClose}>
+      <Dialog
+        as="div"
+        className="fixed inset-0 z-50 flex items-center justify-center"
+        onClose={onClose}
+      >
         <div className="fixed inset-0 bg-black/60" aria-hidden="true" />
         <Transition.Child
           as={Fragment}
@@ -39,7 +43,7 @@ export default function AddToBasketDialog({ open, onClose, onAdd }: Props) {
           leaveFrom="opacity-100 scale-100"
           leaveTo="opacity-0 scale-95"
         >
-          <div className="bg-white rounded shadow-lg w-[min(90vw,420px)] p-6 space-y-6">
+          <Dialog.Panel className="relative z-10 bg-white rounded shadow-lg w-[min(90vw,420px)] p-6 space-y-6">
             <h2 className="font-domine text-xl text-[--walty-teal]">Choose an option</h2>
             <ul className="space-y-2">
               {OPTIONS.map((opt) => (
@@ -64,7 +68,7 @@ export default function AddToBasketDialog({ open, onClose, onAdd }: Props) {
                 Add to basket
               </button>
             </div>
-          </div>
+          </Dialog.Panel>
         </Transition.Child>
       </Dialog>
     </Transition.Root>

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -718,10 +718,6 @@ const handleProofAll = async () => {
       <AddToBasketDialog
         open={basketOpen}
         onClose={() => setBasketOpen(false)}
-        onAdd={(sku) => {
-          console.log('add to basket', sku)
-          setBasketOpen(false)
-        }}
       />
     </div>
   )

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -25,6 +25,7 @@ import EditorCommands                   from './EditorCommands'
 import SelfieDrawer                     from './SelfieDrawer'
 import CropDrawer                      from './CropDrawer'
 import PreviewModal                    from './PreviewModal'
+import AddToBasketDialog               from './AddToBasketDialog'
 import { CropTool }                     from '@/lib/CropTool'
 import WaltyEditorHeader                from './WaltyEditorHeader'
 import type { TemplatePage }            from './FabricCanvas'
@@ -289,6 +290,9 @@ const [aiPlaceholderId, setAiPlaceholderId] = useState<string | null>(null)
 /* preview modal state */
 const [previewOpen, setPreviewOpen] = useState(false)
 const [previewImgs, setPreviewImgs] = useState<string[]>([])
+
+/* add-to-basket modal state */
+const [basketOpen, setBasketOpen] = useState(false)
 
 /* listen for the event FabricCanvas now emits */
 useEffect(() => {
@@ -560,7 +564,7 @@ const handleProofAll = async () => {
     >
       <WaltyEditorHeader                     /* ② mount new component */
         onPreview={handlePreview}
-        onAddToBasket={() => console.log("basket")}
+        onAddToBasket={() => setBasketOpen(true)}
         height={72}                          /* match the design */
       />
 
@@ -710,6 +714,14 @@ const handleProofAll = async () => {
         open={previewOpen}
         images={previewImgs}
         onClose={() => setPreviewOpen(false)}
+      />
+      <AddToBasketDialog
+        open={basketOpen}
+        onClose={() => setBasketOpen(false)}
+        onAdd={(sku) => {
+          console.log('add to basket', sku)
+          setBasketOpen(false)
+        }}
       />
     </div>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Domine, Inter } from "next/font/google";
 import { recoleta } from "@/lib/fonts"; // local font
 import WaltyNavWrapper from "@/components/site/WaltyNavWrapper"; // shows/hides navbar
+import { BasketProvider } from "@/lib/useBasket";
 
 export const domine = Domine({
   weight: ["400", "700"],
@@ -28,8 +29,10 @@ export default function RootLayout({
       <body
         className={`${inter.variable} ${domine.variable} ${recoleta.variable}`}
       >
-        <WaltyNavWrapper />
-        {children}
+        <BasketProvider>
+          <WaltyNavWrapper />
+          {children}
+        </BasketProvider>
       </body>
     </html>
   );

--- a/components/site/BasketPopover.tsx
+++ b/components/site/BasketPopover.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useBasket } from '@/lib/useBasket'
+import Popover from '@/app/components/toolbar/Popover'
+import Link from 'next/link'
+
+interface Props {
+  anchor: HTMLElement | null
+  open: boolean
+  onClose: () => void
+}
+
+export default function BasketPopover({ anchor, open, onClose }: Props) {
+  const { items, removeItem, updateQty } = useBasket()
+
+  return (
+    <Popover anchor={anchor} open={open} onClose={onClose}>
+      <div className="space-y-3 w-60">
+        {items.length === 0 ? (
+          <p className="text-sm">Your basket is empty.</p>
+        ) : (
+          items.map((it) => (
+            <div key={it.sku} className="border-b pb-2 last:border-none last:pb-0">
+              <div className="flex justify-between items-center">
+                <span className="font-medium">{it.sku}</span>
+                <button
+                  onClick={() => removeItem(it.sku)}
+                  className="text-sm text-red-600 hover:underline"
+                >
+                  Remove
+                </button>
+              </div>
+              <div className="flex items-center gap-2 mt-1">
+                <button
+                  className="px-2 py-0.5 border rounded"
+                  onClick={() => updateQty(it.sku, Math.max(1, it.qty - 1))}
+                >
+                  -
+                </button>
+                <input
+                  type="number"
+                  value={it.qty}
+                  onChange={(e) => updateQty(it.sku, Math.max(1, parseInt(e.target.value) || 1))}
+                  className="w-12 border rounded text-center text-sm"
+                />
+                <button
+                  className="px-2 py-0.5 border rounded"
+                  onClick={() => updateQty(it.sku, it.qty + 1)}
+                >
+                  +
+                </button>
+              </div>
+              <Link
+                href={`/cards/${it.sku}/customise`}
+                className="mt-2 inline-block text-sm text-[--walty-teal] hover:underline"
+              >
+                Preview &amp; customise
+              </Link>
+            </div>
+          ))
+        )}
+      </div>
+    </Popover>
+  )
+}

--- a/components/site/BasketPopover.tsx
+++ b/components/site/BasketPopover.tsx
@@ -19,45 +19,65 @@ export default function BasketPopover({ anchor, open, onClose }: Props) {
         {items.length === 0 ? (
           <p className="text-sm">Your basket is empty.</p>
         ) : (
-          items.map((it) => (
-            <div key={it.sku} className="border-b pb-2 last:border-none last:pb-0">
-              <div className="flex justify-between items-center">
-                <span className="font-medium">{it.sku}</span>
-                <button
-                  onClick={() => removeItem(it.sku)}
-                  className="text-sm text-red-600 hover:underline"
-                >
-                  Remove
-                </button>
-              </div>
-              <div className="flex items-center gap-2 mt-1">
-                <button
-                  className="px-2 py-0.5 border rounded"
-                  onClick={() => updateQty(it.sku, Math.max(1, it.qty - 1))}
-                >
-                  -
-                </button>
-                <input
-                  type="number"
-                  value={it.qty}
-                  onChange={(e) => updateQty(it.sku, Math.max(1, parseInt(e.target.value) || 1))}
-                  className="w-12 border rounded text-center text-sm"
-                />
-                <button
-                  className="px-2 py-0.5 border rounded"
-                  onClick={() => updateQty(it.sku, it.qty + 1)}
-                >
-                  +
-                </button>
-              </div>
-              <Link
-                href={`/cards/${it.sku}/customise`}
-                className="mt-2 inline-block text-sm text-[--walty-teal] hover:underline"
+          <>
+            {items.map((it) => (
+              <div
+                key={it.sku}
+                className="border-b pb-2 last:border-none last:pb-0 flex gap-2"
               >
-                Preview &amp; customise
-              </Link>
-            </div>
-          ))
+                <img
+                  src="/templates/daisy/daisy-front-cover.jpg"
+                  alt="thumbnail"
+                  className="w-12 h-12 rounded object-cover"
+                />
+                <div className="flex-grow">
+                  <div className="flex justify-between items-center">
+                    <span className="font-medium">{it.sku}</span>
+                    <button
+                      onClick={() => removeItem(it.sku)}
+                      className="text-sm text-red-600 hover:underline"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                  <div className="flex items-center gap-2 mt-1">
+                    <button
+                      className="px-2 py-0.5 border rounded"
+                      onClick={() => updateQty(it.sku, Math.max(1, it.qty - 1))}
+                    >
+                      -
+                    </button>
+                    <input
+                      type="number"
+                      value={it.qty}
+                      onChange={(e) =>
+                        updateQty(it.sku, Math.max(1, parseInt(e.target.value) || 1))
+                      }
+                      className="w-12 border rounded text-center text-sm"
+                    />
+                    <button
+                      className="px-2 py-0.5 border rounded"
+                      onClick={() => updateQty(it.sku, it.qty + 1)}
+                    >
+                      +
+                    </button>
+                  </div>
+                  <Link
+                    href={`/cards/${it.sku}/customise`}
+                    className="mt-2 inline-block text-sm text-[--walty-teal] hover:underline"
+                  >
+                    Preview &amp; customise
+                  </Link>
+                </div>
+              </div>
+            ))}
+            <Link
+              href="/checkout"
+              className="block text-center mt-2 rounded-md bg-[--walty-orange] text-[--walty-cream] px-4 py-2 font-semibold hover:bg-orange-600"
+            >
+              View basket
+            </Link>
+          </>
         )}
       </div>
     </Popover>

--- a/components/site/WaltyNav.tsx
+++ b/components/site/WaltyNav.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Search, User, ShoppingBag, Crown } from "lucide-react";
 import BasketPopover from "./BasketPopover";
+import { useBasket } from "@/lib/useBasket";
 
 export default function WaltyNav() {
   /* show shadow when scrolled */
@@ -19,6 +20,8 @@ export default function WaltyNav() {
 
   const basketRef = useRef<HTMLButtonElement | null>(null);
   const [basketOpen, setBasketOpen] = useState(false);
+  const { items } = useBasket();
+  const itemCount = items.reduce((t, it) => t + it.qty, 0);
 
   return (
     <header
@@ -54,8 +57,19 @@ export default function WaltyNav() {
               <User className="w-[30px] h-[30px] stroke-[--walty-orange]" />
               Account
             </Link>
-            <button ref={basketRef} onClick={() => setBasketOpen((o) => !o)} className="flex flex-col items-center gap-1 hover:text-[--walty-teal]">
+            <button
+              ref={basketRef}
+              onClick={() => setBasketOpen((o) => !o)}
+              className="relative flex flex-col items-center gap-1 hover:text-[--walty-teal]"
+            >
               <ShoppingBag className="w-[30px] h-[30px] stroke-[--walty-orange]" />
+              {itemCount > 0 && (
+                <span
+                  className="absolute -top-1 -right-2 rounded-full bg-[--walty-orange] text-[--walty-cream] text-[10px] leading-none px-1"
+                >
+                  {itemCount}
+                </span>
+              )}
               Basket
             </button>
           </nav>

--- a/components/site/WaltyNav.tsx
+++ b/components/site/WaltyNav.tsx
@@ -1,10 +1,11 @@
 /* components/site/WaltyNav.tsx – tighter 64 px top row */
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Search, User, ShoppingBag, Crown } from "lucide-react";
+import BasketPopover from "./BasketPopover";
 
 export default function WaltyNav() {
   /* show shadow when scrolled */
@@ -15,6 +16,9 @@ export default function WaltyNav() {
     window.addEventListener("scroll", toggle, { passive: true });
     return () => window.removeEventListener("scroll", toggle);
   }, []);
+
+  const basketRef = useRef<HTMLButtonElement | null>(null);
+  const [basketOpen, setBasketOpen] = useState(false);
 
   return (
     <header
@@ -42,21 +46,20 @@ export default function WaltyNav() {
 
           {/* orange icons – 34 px */}
           <nav className="flex items-center gap-16 text-[14px] font-sans ml-auto">
-            {[
-              { href: "/premium", label: "Premium", Icon: Crown },
-              { href: "/account", label: "Account", Icon: User },
-              { href: "/basket",  label: "Basket",  Icon: ShoppingBag },
-            ].map(({ href, label, Icon }) => (
-              <Link
-                key={label}
-                href={href}
-                className="flex flex-col items-center gap-1 hover:text-[--walty-teal]"
-              >
-                <Icon className="w-[30px] h-[30px] stroke-[--walty-orange]" />
-                {label}
-              </Link>
-            ))}
+            <Link href="/premium" className="flex flex-col items-center gap-1 hover:text-[--walty-teal]">
+              <Crown className="w-[30px] h-[30px] stroke-[--walty-orange]" />
+              Premium
+            </Link>
+            <Link href="/account" className="flex flex-col items-center gap-1 hover:text-[--walty-teal]">
+              <User className="w-[30px] h-[30px] stroke-[--walty-orange]" />
+              Account
+            </Link>
+            <button ref={basketRef} onClick={() => setBasketOpen((o) => !o)} className="flex flex-col items-center gap-1 hover:text-[--walty-teal]">
+              <ShoppingBag className="w-[30px] h-[30px] stroke-[--walty-orange]" />
+              Basket
+            </button>
           </nav>
+          <BasketPopover anchor={basketRef.current} open={basketOpen} onClose={() => setBasketOpen(false)} />
         </div>
 
         {/* ── row B : filters ──────────────────────────────── */}

--- a/lib/useBasket.tsx
+++ b/lib/useBasket.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+export interface BasketItem {
+  sku: string;
+  qty: number;
+}
+
+interface BasketContextValue {
+  items: BasketItem[];
+  addItem: (sku: string) => void;
+}
+
+const BasketContext = createContext<BasketContextValue>({
+  items: [],
+  addItem: () => {},
+});
+
+export function BasketProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = useState<BasketItem[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const stored = window.localStorage.getItem("basket");
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem("basket", JSON.stringify(items));
+    } catch {
+      // ignore
+    }
+  }, [items]);
+
+  const addItem = (sku: string) => {
+    setItems((prev) => {
+      const existing = prev.find((it) => it.sku === sku);
+      if (existing) {
+        return prev.map((it) =>
+          it.sku === sku ? { ...it, qty: it.qty + 1 } : it
+        );
+      }
+      return [...prev, { sku, qty: 1 }];
+    });
+  };
+
+  return (
+    <BasketContext.Provider value={{ items, addItem }}>
+      {children}
+    </BasketContext.Provider>
+  );
+}
+
+export function useBasket() {
+  return useContext(BasketContext);
+}

--- a/lib/useBasket.tsx
+++ b/lib/useBasket.tsx
@@ -10,11 +10,15 @@ export interface BasketItem {
 interface BasketContextValue {
   items: BasketItem[];
   addItem: (sku: string) => void;
+  removeItem: (sku: string) => void;
+  updateQty: (sku: string, qty: number) => void;
 }
 
 const BasketContext = createContext<BasketContextValue>({
   items: [],
   addItem: () => {},
+  removeItem: () => {},
+  updateQty: () => {},
 });
 
 export function BasketProvider({ children }: { children: React.ReactNode }) {
@@ -48,8 +52,18 @@ export function BasketProvider({ children }: { children: React.ReactNode }) {
     });
   };
 
+  const removeItem = (sku: string) => {
+    setItems((prev) => prev.filter((it) => it.sku !== sku));
+  };
+
+  const updateQty = (sku: string, qty: number) => {
+    setItems((prev) =>
+      prev.map((it) => (it.sku === sku ? { ...it, qty } : it))
+    );
+  };
+
   return (
-    <BasketContext.Provider value={{ items, addItem }}>
+    <BasketContext.Provider value={{ items, addItem, removeItem, updateQty }}>
       {children}
     </BasketContext.Provider>
   );


### PR DESCRIPTION
## Summary
- scaffold a new checkout page
- implement basket with qty and address selector
- slide-in drawer for adding addresses
- order summary and payment placeholder
- simple progress steps

## Testing
- `npm run lint` *(fails: React Hook rules in existing files)*
- `npx eslint app/checkout`

------
https://chatgpt.com/codex/tasks/task_e_6850349bfbc88323a3ae7d4d157aa69c