### PR TITLE
Add API for handle-based order building

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Create a `.env` file and include your Google Fonts API key:
 
 ```
 GOOGLE_FONTS_API_KEY=your_key_here
+PRODIGI_API_KEY=your_prodigi_key
 ```
 
 This is required for the font picker to load the full list of Google Fonts.

--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getProdigiPayload } from '@/commerce/getProdigiPayload'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { variantHandle, fulfilHandle, assets, address, copies = 1 } = await req.json()
+    if (typeof variantHandle !== 'string' || typeof fulfilHandle !== 'string' || !Array.isArray(assets)) {
+      return NextResponse.json({ error: 'bad input' }, { status: 400 })
+    }
+
+    const payload = await getProdigiPayload(variantHandle, fulfilHandle, assets, copies)
+
+    const order = {
+      shippingMethod: payload.shippingMethod,
+      recipient: address || null,
+      items: [ {
+        sku: payload.sku,
+        copies: payload.copies,
+        sizing: payload.sizing,
+        assets: payload.assets,
+      } ]
+    }
+
+    return NextResponse.json(order)
+  } catch (err) {
+    console.error('[order]', err)
+    return NextResponse.json({ error: 'server-error' }, { status: 500 })
+  }
+}

--- a/app/cards/[slug]/customise/CustomiseClient.tsx
+++ b/app/cards/[slug]/customise/CustomiseClient.tsx
@@ -5,7 +5,7 @@
 
    import CardEditor from "@/app/components/CardEditor";
    
-   export default function CustomiseClient({ tpl }: { tpl: any }) {
+   export default function CustomiseClient({ slug, title, coverImage, tpl }: { slug: string; title: string; coverImage?: string; tpl: any }) {
      // 1️⃣ keep the old log
      console.log("TPL pages 👉", tpl.pages);
    
@@ -21,6 +21,9 @@
          initialPages={tpl.pages}
          printSpec={tpl.spec}
          previewSpec={tpl.previewSpec}
+         slug={slug}
+         title={title}
+         coverImage={coverImage}
          mode="customer"
        />
      );

--- a/app/cards/[slug]/customise/page.tsx
+++ b/app/cards/[slug]/customise/page.tsx
@@ -4,6 +4,7 @@
 
 import CustomiseClient from "./CustomiseClient";
 import { getTemplatePages } from '@/app/library/getTemplatePages'
+import { sanityPreview } from '@/sanity/lib/client'
 
 // Path: app/cards/[slug]/customise/page.tsx
 // This is a **server component**. In Next 15 `params` is a Promise, so we need to
@@ -17,9 +18,20 @@ export default async function CustomisePage({
   // 🡇 open the "params" gift‑box and pull out slug
   const { slug } = await params;
 
-  const { pages, spec, previewSpec } = await getTemplatePages(slug)
+  const { pages, spec, previewSpec, coverImage } = await getTemplatePages(slug)
+  const meta = await sanityPreview.fetch<{title:string}>(
+    `*[_type=="cardTemplate" && slug.current==$s][0]{title}`,
+    { s: slug }
+  )
   console.log('SERVER tpl.pages =', pages)
   console.log('↳ template printSpec', spec)
 
-  return <CustomiseClient tpl={{ pages, spec, previewSpec }} />;
+  return (
+    <CustomiseClient
+      slug={slug}
+      title={meta?.title || slug}
+      coverImage={coverImage}
+      tpl={{ pages, spec, previewSpec }}
+    />
+  )
 }

--- a/app/checkout/CheckoutClient.tsx
+++ b/app/checkout/CheckoutClient.tsx
@@ -76,6 +76,37 @@ export default function CheckoutClient({
     );
   };
 
+  const sendOrders = async () => {
+    for (const item of cartItems) {
+      const addr = addresses.find((a) => a.id === item.addressId);
+      try {
+        const res = await fetch('/api/order', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            variantHandle: item.variant,
+            fulfilHandle: 'toSender_flat_std',
+            assets: [{ url: item.coverUrl }],
+            copies: item.qty,
+            address: addr || undefined,
+          }),
+        });
+        const data = await res.json().catch(() => ({}));
+        console.log('order', data);
+      } catch (err) {
+        console.error('order error', err);
+      }
+    }
+  };
+
+  const handleContinue = async (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    e.preventDefault();
+    await sendOrders();
+    document.getElementById('payment')?.scrollIntoView({ behavior: 'smooth' });
+  };
+
   const subtotal = cartItems.reduce((sum, it) => sum + it.qty * it.price, 0);
   const shipping = 0; // TODO: replace with API calculation
   const vat = 0; // TODO: replace with API calculation
@@ -117,11 +148,12 @@ export default function CheckoutClient({
         </div>
         <div className="lg:w-1/3 lg:sticky lg:top-4 mt-8 lg:mt-0">
           <Summary subtotal={subtotal} shipping={shipping} vat={vat} total={total} />
-          <a href="#payment" className="block mt-4">
-            <button className="w-full rounded-md bg-walty-orange text-walty-cream px-4 py-2 hover:bg-orange-600 transition">
-              Continue to payment
-            </button>
-          </a>
+          <button
+            onClick={handleContinue}
+            className="block w-full mt-4 rounded-md bg-walty-orange text-walty-cream px-4 py-2 hover:bg-orange-600 transition"
+          >
+            Continue to payment
+          </button>
         </div>
       </div>
 

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,27 +1,27 @@
-import CheckoutClient from './CheckoutClient';
+import CheckoutClient from './CheckoutClient'
+import { sanityFetch } from '@/lib/sanityClient'
+import { urlFor } from '@/sanity/lib/image'
 
-export default function CheckoutPage() {
-  // Seed dummy cart items and addresses
-  const items = [
-    {
-      id: '1',
-      coverUrl: '/templates/daisy/daisy-front-cover.jpg',
-      title: 'Birthday Card',
-      sku: 'BDY-001',
-      variant: 'classic',
-      qty: 1,
-      price: 3.5,
-    },
-    {
-      id: '2',
-      coverUrl: '/templates/daisy/daisy-inner-left.jpg',
-      title: 'Thank You Card',
-      sku: 'THX-002',
-      variant: 'mini',
-      qty: 2,
-      price: 2.5,
-    },
-  ];
+export default async function CheckoutPage() {
+  // Fetch a couple of live card templates to populate the basket
+  const products = await sanityFetch<{
+    _id: string
+    title: string
+    slug: { current: string }
+    coverImage?: any
+  }[]>(
+    `*[_type=="cardTemplate" && isLive==true]{_id,title,slug,coverImage}[0...2]`
+  )
+
+  const items = products.map((p) => ({
+    id: p._id,
+    coverUrl: p.coverImage ? urlFor(p.coverImage).width(160).height(224).url() : '',
+    title: p.title,
+    sku: p.slug.current,
+    variant: 'classic',
+    qty: 1,
+    price: 3.5,
+  }))
 
   const addresses = [
     {

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,26 +1,19 @@
+'use client'
 import CheckoutClient from './CheckoutClient'
-import { sanityFetch } from '@/lib/sanityClient'
-import { urlFor } from '@/sanity/lib/image'
+import { useBasket } from '@/lib/useBasket'
+import { CARD_SIZES } from './sizeOptions'
 
-export default async function CheckoutPage() {
-  // Fetch a couple of live card templates to populate the basket
-  const products = await sanityFetch<{
-    _id: string
-    title: string
-    slug: { current: string }
-    coverImage?: any
-  }[]>(
-    `*[_type=="cardTemplate" && isLive==true]{_id,title,slug,coverImage}[0...2]`
-  )
+export default function CheckoutPage() {
+  const { items } = useBasket()
 
-  const items = products.map((p) => ({
-    id: p._id,
-    coverUrl: p.coverImage ? urlFor(p.coverImage).width(160).height(224).url() : '',
-    title: p.title,
-    sku: p.slug.current,
-    variant: 'classic',
-    qty: 1,
-    price: 3.5,
+  const cartItems = items.map((it) => ({
+    id: it.id,
+    coverUrl: it.image,
+    title: it.title,
+    sku: it.slug,
+    variant: it.variant,
+    qty: it.qty,
+    price: CARD_SIZES.find((s) => s.id === it.variant)?.price ?? 0,
   }))
 
   const addresses = [
@@ -42,5 +35,5 @@ export default async function CheckoutPage() {
     },
   ];
 
-  return <CheckoutClient initialItems={items} initialAddresses={addresses} />;
+  return <CheckoutClient initialItems={cartItems} initialAddresses={addresses} />;
 }

--- a/app/checkout/sizeOptions.ts
+++ b/app/checkout/sizeOptions.ts
@@ -1,4 +1,4 @@
-import { Square, RectangleHorizontal, Expand } from 'lucide-react'
+import { Square, RectangleHorizontal, Expand, Image } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface CardSize {
@@ -9,6 +9,7 @@ export interface CardSize {
 }
 
 export const CARD_SIZES: CardSize[] = [
+  { id: 'digital', label: 'Digital Card', price: 0, Icon: Image },
   { id: 'mini', label: 'Mini Card', price: 2.5, Icon: Square },
   { id: 'classic', label: 'Classic Card', price: 3.5, Icon: RectangleHorizontal },
   { id: 'giant', label: 'Giant Card', price: 5, Icon: Expand },

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -12,10 +12,10 @@ interface Props {
 }
 
 const OPTIONS = [
-  { label: 'Single card', sku: 'single' },
-  { label: 'Pack of 5', sku: 'pack5' },
-  { label: 'Pack of 10', sku: 'pack10' },
-  { label: 'Pack of 20', sku: 'pack20' },
+  { label: 'Digital Card', sku: 'digital' },
+  { label: 'Mini Card', sku: 'mini' },
+  { label: 'Classic Card', sku: 'classic' },
+  { label: 'Giant Card', sku: 'giant' },
 ]
 
 export default function AddToBasketDialog({ open, onClose, onAdd }: Props) {

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -8,7 +8,10 @@ import { useBasket } from '@/lib/useBasket'
 interface Props {
   open: boolean
   onClose: () => void
-  onAdd?: (sku: string) => void
+  slug: string
+  title: string
+  coverUrl: string
+  onAdd?: (variant: string) => void
 }
 
 const OPTIONS = [
@@ -18,13 +21,13 @@ const OPTIONS = [
   { label: 'Giant Card', sku: 'giant' },
 ]
 
-export default function AddToBasketDialog({ open, onClose, onAdd }: Props) {
+export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, onAdd }: Props) {
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
   const handleAdd = () => {
     if (choice) {
-      addItem(choice)
+      addItem({ slug, title, variant: choice, image: coverUrl })
       onAdd?.(choice)
       onClose()
       setChoice(null)

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -75,6 +75,9 @@ function CoachMark({ anchor, onClose }: { anchor: DOMRect | null; onClose: () =>
 export default function CardEditor({
   initialPages,
   templateId,
+  slug,
+  title,
+  coverImage,
   printSpec,
   previewSpec,
   products = [],
@@ -83,6 +86,9 @@ export default function CardEditor({
 }: {
   initialPages: TemplatePage[] | undefined
   templateId?: string
+  slug: string
+  title: string
+  coverImage?: string
   printSpec?: PrintSpec
   previewSpec?: PreviewSpec
   products?: TemplateProduct[]
@@ -715,6 +721,9 @@ const handleProofAll = async () => {
       <AddToBasketDialog
         open={basketOpen}
         onClose={() => setBasketOpen(false)}
+        slug={slug}
+        title={title}
+        coverUrl={thumbs[0] || coverImage || ''}
       />
     </div>
   )

--- a/commerce/getProdigiPayload.ts
+++ b/commerce/getProdigiPayload.ts
@@ -9,6 +9,7 @@ export interface ProdigiPayload {
   sku: string
   copies: number
   sizing: string
+  shippingMethod: string
   assets: ProdigiAsset[]
 }
 
@@ -18,14 +19,15 @@ export async function getProdigiPayload(
   assets: { url: string }[],
   copies = 1,
 ): Promise<ProdigiPayload> {
-  const query = `*[_type=="skuMap" && variant->variantHandle==$v && fulfil->fulfilHandle==$f][0]{prodigiSku,printAreaId,sizingStrategy}`
-  const map = await sanity.fetch<{prodigiSku:string,printAreaId:string,sizingStrategy:string}>(query, {v: variantHandle, f: fulfilHandle})
+  const query = `*[_type=="skuMap" && variant->variantHandle==$v && fulfil->fulfilHandle==$f][0]{prodigiSku,printAreaId,sizingStrategy,"shippingMethod":fulfil->shippingMethod}`
+  const map = await sanity.fetch<{prodigiSku:string,printAreaId:string,sizingStrategy:string,shippingMethod:string}>(query, {v: variantHandle, f: fulfilHandle})
   if (!map) throw new Error(`SKU mapping not found for ${variantHandle}_${fulfilHandle}`)
 
   return {
     sku: map.prodigiSku,
     copies,
     sizing: map.sizingStrategy,
+    shippingMethod: map.shippingMethod,
     assets: assets.map(a => ({ url: a.url, printArea: map.printAreaId })),
   }
 }

--- a/components/site/BasketPopover.tsx
+++ b/components/site/BasketPopover.tsx
@@ -22,19 +22,19 @@ export default function BasketPopover({ anchor, open, onClose }: Props) {
           <>
             {items.map((it) => (
               <div
-                key={it.sku}
+                key={it.id}
                 className="border-b pb-2 last:border-none last:pb-0 flex gap-2"
               >
                 <img
-                  src="/templates/daisy/daisy-front-cover.jpg"
+                  src={it.image}
                   alt="thumbnail"
                   className="w-12 h-12 rounded object-cover"
                 />
                 <div className="flex-grow">
                   <div className="flex justify-between items-center">
-                    <span className="font-medium">{it.sku}</span>
+                    <span className="font-medium">{it.title}</span>
                     <button
-                      onClick={() => removeItem(it.sku)}
+                      onClick={() => removeItem(it.id)}
                       className="text-sm text-red-600 hover:underline"
                     >
                       Remove
@@ -43,7 +43,7 @@ export default function BasketPopover({ anchor, open, onClose }: Props) {
                   <div className="flex items-center gap-2 mt-1">
                     <button
                       className="px-2 py-0.5 border rounded"
-                      onClick={() => updateQty(it.sku, Math.max(1, it.qty - 1))}
+                      onClick={() => updateQty(it.id, Math.max(1, it.qty - 1))}
                     >
                       -
                     </button>
@@ -51,19 +51,19 @@ export default function BasketPopover({ anchor, open, onClose }: Props) {
                       type="number"
                       value={it.qty}
                       onChange={(e) =>
-                        updateQty(it.sku, Math.max(1, parseInt(e.target.value) || 1))
+                        updateQty(it.id, Math.max(1, parseInt(e.target.value) || 1))
                       }
                       className="w-12 border rounded text-center text-sm"
                     />
                     <button
                       className="px-2 py-0.5 border rounded"
-                      onClick={() => updateQty(it.sku, it.qty + 1)}
+                      onClick={() => updateQty(it.id, it.qty + 1)}
                     >
                       +
                     </button>
                   </div>
                   <Link
-                    href={`/cards/${it.sku}/customise`}
+                    href={`/cards/${it.slug}/customise`}
                     className="mt-2 inline-block text-sm text-[--walty-teal] hover:underline"
                   >
                     Preview &amp; customise

--- a/lib/useBasket.tsx
+++ b/lib/useBasket.tsx
@@ -3,15 +3,19 @@
 import { createContext, useContext, useEffect, useState } from "react";
 
 export interface BasketItem {
-  sku: string;
+  id: string;
+  slug: string;
+  title: string;
+  variant: string;
+  image: string;
   qty: number;
 }
 
 interface BasketContextValue {
   items: BasketItem[];
-  addItem: (sku: string) => void;
-  removeItem: (sku: string) => void;
-  updateQty: (sku: string, qty: number) => void;
+  addItem: (item: { slug: string; title: string; variant: string; image: string }) => void;
+  removeItem: (id: string) => void;
+  updateQty: (id: string, qty: number) => void;
 }
 
 const BasketContext = createContext<BasketContextValue>({
@@ -40,26 +44,25 @@ export function BasketProvider({ children }: { children: React.ReactNode }) {
     }
   }, [items]);
 
-  const addItem = (sku: string) => {
+  const addItem = (item: { slug: string; title: string; variant: string; image: string }) => {
     setItems((prev) => {
-      const existing = prev.find((it) => it.sku === sku);
+      const id = `${item.slug}_${item.variant}`
+      const existing = prev.find((it) => it.id === id)
       if (existing) {
         return prev.map((it) =>
-          it.sku === sku ? { ...it, qty: it.qty + 1 } : it
-        );
+          it.id === id ? { ...it, qty: it.qty + 1 } : it
+        )
       }
-      return [...prev, { sku, qty: 1 }];
-    });
+      return [...prev, { id, qty: 1, ...item }]
+    })
+  }
+
+  const removeItem = (id: string) => {
+    setItems((prev) => prev.filter((it) => it.id !== id))
   };
 
-  const removeItem = (sku: string) => {
-    setItems((prev) => prev.filter((it) => it.sku !== sku));
-  };
-
-  const updateQty = (sku: string, qty: number) => {
-    setItems((prev) =>
-      prev.map((it) => (it.sku === sku ? { ...it, qty } : it))
-    );
+  const updateQty = (id: string, qty: number) => {
+    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, qty } : it)))
   };
 
   return (

--- a/scripts/seedSkuMaps.js
+++ b/scripts/seedSkuMaps.js
@@ -1,73 +1,89 @@
-import 'dotenv/config'
-import {createClient} from '@sanity/client'
+/*  seedSkuMaps.mjs  – run with `node scripts/seedSkuMaps.mjs`
+   ---------------------------------------------------------- */
 
-const sanity = createClient({
-  projectId : process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
-  dataset   : process.env.NEXT_PUBLIC_SANITY_DATASET,
-  apiVersion: '2023-10-01',
-  token     : process.env.SANITY_TOKEN,
-  useCdn    : false,
-})
-
-const VARIANTS = ['gc-mini', 'gc-classic', 'gc-large']
-const FULFILS = [
-  'toRecipient_flat_std',
-  'toRecipient_flat_next',
-  'toRecipient_flat_express',
-  'toSender_flat_std',
-  'toSender_flat_next',
-  'toSender_flat_express',
-]
-
-const STEMS = {
-  'gc-mini': 'GLOBAL-GRE-GLOS-4X6',
-  'gc-classic': 'GLOBAL-GRE-GLOS-5X7',
-  'gc-large': 'GLOBAL-GRE-GLOS-A4',
-}
-
-function suffixFor(handle) {
-  if (handle.startsWith('toRecipient')) return '-REC'
-  if (handle.startsWith('toSender')) return '-DIR'
-  return ''
-}
-
-async function run() {
-  const variants = await sanity.fetch(
-    `*[_type=="cardProduct" && variantHandle in $v]{_id,variantHandle}`,
-    {v: VARIANTS},
-  )
-  const fulfils = await sanity.fetch(
-    `*[_type=="fulfilOption" && fulfilHandle in $f]{_id,fulfilHandle}`,
-    {f: FULFILS},
-  )
-
-  let count = 0
-
-  for (const v of variants) {
-    const stem = STEMS[v.variantHandle]
-    if (!stem) continue
-    for (const f of fulfils) {
-      const suffix = suffixFor(f.fulfilHandle)
-      if (!suffix) continue
-      const id = `${v.variantHandle}_${f.fulfilHandle}`
-      await sanity.createOrReplace({
-        _id: id,
-        _type: 'skuMap',
-        variant: {_type: 'reference', _ref: v._id},
-        fulfil: {_type: 'reference', _ref: f._id},
-        prodigiSku: `${stem}${suffix}`,
-        printAreaId: 'front',
-        sizingStrategy: 'fillPrintArea',
-        active: true,
-      })
-      count++
-    }
-  }
-
-  console.log(`✅ ${count} skuMap docs seeded`)
-}
-
-run().catch(err => {
-  console.error(err)
-  process.exit(1)
-})
+   import dotenv from 'dotenv'
+   dotenv.config({ path: '.env.local' })        // ← picks up your secrets
+   
+   import { createClient } from '@sanity/client'
+   
+   const sanity = createClient({
+     projectId : process.env.SANITY_STUDIO_PROJECT_ID,
+     dataset   : process.env.SANITY_STUDIO_DATASET,
+     apiVersion: '2023-10-01',
+     token     : process.env.SANITY_WRITE_TOKEN,
+     useCdn    : false
+   })
+   
+   /* ---- handles & helpers ------------------------------------------ */
+   
+   const VARIANTS = ['gc-mini', 'gc-classic', 'gc-large']
+   
+   const FULFILS = [
+     'toRecipient_flat_std',
+     'toRecipient_flat_next',
+     'toRecipient_flat_express',
+     'toSender_flat_std',
+     'toSender_flat_next',
+     'toSender_flat_express'
+   ]
+   
+   const STEMS = {
+     'gc-mini'   : 'GLOBAL-GRE-GLOS-4X6',
+     'gc-classic': 'GLOBAL-GRE-GLOS-5X7',
+     'gc-large'  : 'GLOBAL-GRE-GLOS-A4'
+   }
+   
+   const suffixFor = fh =>
+     fh.startsWith('toRecipient') ? '-REC'
+     : fh.startsWith('toSender')  ? '-DIR'
+     : ''
+   
+   /* ---- main runner ------------------------------------------------ */
+   
+   async function run () {
+     /* 1. fetch refs */
+     const variants = await sanity.fetch(
+       `*[_type=="cardProduct" && variantHandle in $v]{ _id, variantHandle }`,
+       { v: VARIANTS }
+     )
+     const fulfils  = await sanity.fetch(
+       `*[_type=="fulfilOption" && fulfilHandle in $f]{ _id, fulfilHandle }`,
+       { f: FULFILS }
+     )
+   
+     console.log(`found variants:${variants.length} fulfils:${fulfils.length}`)
+   
+     /* 2. build/create skuMaps */
+     let count = 0
+     const txn = sanity.transaction()
+   
+     for (const v of variants) {
+       const stem = STEMS[v.variantHandle]
+       if (!stem) continue
+   
+       for (const f of fulfils) {
+         const suffix = suffixFor(f.fulfilHandle)
+         if (!suffix) continue
+   
+         txn.createOrReplace({
+           _id: `${v.variantHandle}_${f.fulfilHandle}`,
+           _type: 'skuMap',
+           variant: { _type: 'reference', _ref: v._id },
+           fulfil : { _type: 'reference', _ref: f._id },
+           prodigiSku: `${stem}${suffix}`,
+           printAreaId: 'front',
+           sizingStrategy: 'fillPrintArea',
+           active: true
+         })
+         count++
+       }
+     }
+   
+     await txn.commit()
+     console.log(`✅  seeded / refreshed ${count} skuMap documents`)
+   }
+   
+   run().catch(err => {
+     console.error('❌ seed failed:', err)
+     process.exit(1)
+   })

--- a/scripts/seedSkuMaps.js
+++ b/scripts/seedSkuMaps.js
@@ -1,0 +1,73 @@
+import 'dotenv/config'
+import {createClient} from '@sanity/client'
+
+const sanity = createClient({
+  projectId : process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+  dataset   : process.env.NEXT_PUBLIC_SANITY_DATASET,
+  apiVersion: '2023-10-01',
+  token     : process.env.SANITY_TOKEN,
+  useCdn    : false,
+})
+
+const VARIANTS = ['gc-mini', 'gc-classic', 'gc-large']
+const FULFILS = [
+  'toRecipient_flat_std',
+  'toRecipient_flat_next',
+  'toRecipient_flat_express',
+  'toSender_flat_std',
+  'toSender_flat_next',
+  'toSender_flat_express',
+]
+
+const STEMS = {
+  'gc-mini': 'GLOBAL-GRE-GLOS-4X6',
+  'gc-classic': 'GLOBAL-GRE-GLOS-5X7',
+  'gc-large': 'GLOBAL-GRE-GLOS-A4',
+}
+
+function suffixFor(handle) {
+  if (handle.startsWith('toRecipient')) return '-REC'
+  if (handle.startsWith('toSender')) return '-DIR'
+  return ''
+}
+
+async function run() {
+  const variants = await sanity.fetch(
+    `*[_type=="cardProduct" && variantHandle in $v]{_id,variantHandle}`,
+    {v: VARIANTS},
+  )
+  const fulfils = await sanity.fetch(
+    `*[_type=="fulfilOption" && fulfilHandle in $f]{_id,fulfilHandle}`,
+    {f: FULFILS},
+  )
+
+  let count = 0
+
+  for (const v of variants) {
+    const stem = STEMS[v.variantHandle]
+    if (!stem) continue
+    for (const f of fulfils) {
+      const suffix = suffixFor(f.fulfilHandle)
+      if (!suffix) continue
+      const id = `${v.variantHandle}_${f.fulfilHandle}`
+      await sanity.createOrReplace({
+        _id: id,
+        _type: 'skuMap',
+        variant: {_type: 'reference', _ref: v._id},
+        fulfil: {_type: 'reference', _ref: f._id},
+        prodigiSku: `${stem}${suffix}`,
+        printAreaId: 'front',
+        sizingStrategy: 'fillPrintArea',
+        active: true,
+      })
+      count++
+    }
+  }
+
+  console.log(`✅ ${count} skuMap docs seeded`)
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- expand `getProdigiPayload` to include `shippingMethod`
- add `/api/order` route to build order data from variant/fulfil handles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685303ffa27c8323a20f714a4b107d33