### PR TITLE
Move variant handle selection to frontend

### DIFF
--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -14,6 +14,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'bad input' }, { status: 400 })
     }
 
+    console.log('asset urls →', assets)
+
     const payload = await getProdigiPayload(variantHandle, fulfilHandle, assets, copies)
 
     let recipient: any = null

--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -26,6 +26,10 @@ export async function POST(req: NextRequest) {
         assets: payload.assets,
       } ]
     }
+
+    // Log the outbound payload so developers can verify exactly
+    // what is being sent to the Prodigi API
+    console.log('[order] sending to Prodigi:', JSON.stringify(order, null, 2))
     if (!PRODIGI_API_KEY) {
       console.warn('PRODIGI_API_KEY not configured; returning order JSON')
       return NextResponse.json(order)

--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -16,9 +16,24 @@ export async function POST(req: NextRequest) {
 
     const payload = await getProdigiPayload(variantHandle, fulfilHandle, assets, copies)
 
+    let recipient: any = null
+    if (address) {
+      const { id, name, line1, city, postcode, country } = address
+      recipient = {
+        name,
+        ...(id ? { id } : {}),
+        address: {
+          line1,
+          townOrCity: city,
+          postalOrZipCode: postcode,
+          countryCode: country === 'UK' ? 'GB' : country,
+        },
+      }
+    }
+
     const order = {
       shippingMethod: payload.shippingMethod,
-      recipient: address || null,
+      recipient,
       items: [ {
         sku: payload.sku,
         copies: payload.copies,

--- a/app/cards/[slug]/customise/CustomiseClient.tsx
+++ b/app/cards/[slug]/customise/CustomiseClient.tsx
@@ -1,31 +1,28 @@
-/* app/cards/[slug]/customise/CustomiseClient.tsx
-   (replace the whole file with this) */
+"use client";
 
-   "use client";
+import CardEditor from "@/app/components/CardEditor";
 
-   import CardEditor from "@/app/components/CardEditor";
-   
-   export default function CustomiseClient({ slug, title, coverImage, tpl }: { slug: string; title: string; coverImage?: string; tpl: any }) {
-     // 1️⃣ keep the old log
-     console.log("TPL pages 👉", tpl.pages);
-   
-     // 2️⃣ NEW: put them on window so we can inspect in DevTools
-     if (typeof window !== "undefined") {
-       (window as any).tplPages = tpl.pages;
-       (window as any).tplPreview = tpl.previewSpec;
-     }
-   
-     // 3️⃣ use customer mode so shoppers get the streamlined editor
-     return (
-       <CardEditor
-         initialPages={tpl.pages}
-         printSpec={tpl.spec}
-         previewSpec={tpl.previewSpec}
-         products={tpl.products}
-         slug={slug}
-         title={title}
-         coverImage={coverImage}
-         mode="customer"
-       />
-     );
-   }
+export default function CustomiseClient({ slug, title, coverImage, tpl }: { slug: string; title: string; coverImage?: string; tpl: any }) {
+  // keep the old log
+  console.log("TPL pages 👉", tpl.pages);
+
+  // put them on window so we can inspect in DevTools
+  if (typeof window !== "undefined") {
+    (window as any).tplPages = tpl.pages;
+    (window as any).tplPreview = tpl.previewSpec;
+  }
+
+  // use customer mode so shoppers get the streamlined editor
+  return (
+    <CardEditor
+      initialPages={tpl.pages}
+      printSpec={tpl.spec}
+      previewSpec={tpl.previewSpec}
+      products={tpl.products}
+      slug={slug}
+      title={title}
+      coverImage={coverImage}
+      mode="customer"
+    />
+  );
+}

--- a/app/cards/[slug]/customise/CustomiseClient.tsx
+++ b/app/cards/[slug]/customise/CustomiseClient.tsx
@@ -21,6 +21,7 @@
          initialPages={tpl.pages}
          printSpec={tpl.spec}
          previewSpec={tpl.previewSpec}
+         products={tpl.products}
          slug={slug}
          title={title}
          coverImage={coverImage}

--- a/app/cards/[slug]/customise/page.tsx
+++ b/app/cards/[slug]/customise/page.tsx
@@ -18,7 +18,7 @@ export default async function CustomisePage({
   // 🡇 open the "params" gift‑box and pull out slug
   const { slug } = await params;
 
-  const { pages, spec, previewSpec, coverImage } = await getTemplatePages(slug)
+  const { pages, spec, previewSpec, coverImage, products } = await getTemplatePages(slug)
   const meta = await sanityPreview.fetch<{title:string}>(
     `*[_type=="cardTemplate" && slug.current==$s][0]{title}`,
     { s: slug }
@@ -31,7 +31,7 @@ export default async function CustomisePage({
       slug={slug}
       title={meta?.title || slug}
       coverImage={coverImage}
-      tpl={{ pages, spec, previewSpec }}
+      tpl={{ pages, spec, previewSpec, products }}
     />
   )
 }

--- a/app/checkout/CheckoutClient.tsx
+++ b/app/checkout/CheckoutClient.tsx
@@ -87,7 +87,7 @@ export default function CheckoutClient({
           body: JSON.stringify({
             variantHandle: item.variant,
             fulfilHandle: 'toSender_flat_std',
-            assets: [{ url: item.proofUrl || item.coverUrl }],
+            assets: [{ url: item.proofUrl }],
             copies: item.qty,
             address: addr || undefined,
           }),

--- a/app/checkout/CheckoutClient.tsx
+++ b/app/checkout/CheckoutClient.tsx
@@ -9,6 +9,7 @@ import { CARD_SIZES } from './sizeOptions';
 export interface CartItem {
   id: string;
   coverUrl: string;
+  proofUrl: string;
   title: string;
   sku: string;
   variant: string;
@@ -86,7 +87,7 @@ export default function CheckoutClient({
           body: JSON.stringify({
             variantHandle: item.variant,
             fulfilHandle: 'toSender_flat_std',
-            assets: [{ url: item.coverUrl }],
+            assets: [{ url: item.proofUrl || item.coverUrl }],
             copies: item.qty,
             address: addr || undefined,
           }),

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -9,6 +9,7 @@ export default function CheckoutPage() {
   const cartItems = items.map((it) => ({
     id: it.id,
     coverUrl: it.image,
+    proofUrl: it.proof,
     title: it.title,
     sku: it.slug,
     variant: it.variant,

--- a/app/checkout/sizeOptions.ts
+++ b/app/checkout/sizeOptions.ts
@@ -10,7 +10,7 @@ export interface CardSize {
 
 export const CARD_SIZES: CardSize[] = [
   { id: 'digital', label: 'Digital Card', price: 0, Icon: Image },
-  { id: 'mini', label: 'Mini Card', price: 2.5, Icon: Square },
-  { id: 'classic', label: 'Classic Card', price: 3.5, Icon: RectangleHorizontal },
-  { id: 'giant', label: 'Giant Card', price: 5, Icon: Expand },
+  { id: 'gc-mini', label: 'Mini Card', price: 2.5, Icon: Square },
+  { id: 'gc-classic', label: 'Classic Card', price: 3.5, Icon: RectangleHorizontal },
+  { id: 'gc-large', label: 'Giant Card', price: 5, Icon: Expand },
 ]

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -26,7 +26,14 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
-  const options = products?.map(p => ({ label: p.title, handle: p.variantHandle })) || DEFAULT_OPTIONS
+  const canonical: Record<string, string> = {
+    mini: 'gc-mini',
+    classic: 'gc-classic',
+    giant: 'gc-large',
+  }
+  const options =
+    products?.map(p => ({ label: p.title, handle: canonical[p.variantHandle] ?? p.variantHandle }))
+    || DEFAULT_OPTIONS
 
   const handleAdd = () => {
     if (choice) {

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -40,12 +40,15 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
           proof = url
         } else {
           console.warn('Proof generation failed for', choice)
+          return
         }
       } catch (err) {
         console.error('proof generation', err)
+        return
       }
     }
 
+    if (!proof) return
     addItem({ slug, title, variant: choice, image: coverUrl, proof })
     onAdd?.(choice)
     onClose()

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -30,13 +30,26 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
   const options = products?.map(p => ({ label: p.title, handle: p.variantHandle })) || DEFAULT_OPTIONS
 
   const handleAdd = async () => {
-    if (choice) {
-      const proof = (await generateProofUrl?.(choice)) || ''
-      addItem({ slug, title, variant: choice, image: coverUrl, proof })
-      onAdd?.(choice)
-      onClose()
-      setChoice(null)
+    if (!choice) return
+
+    let proof = ''
+    if (generateProofUrl) {
+      try {
+        const url = await generateProofUrl(choice)
+        if (typeof url === 'string' && url) {
+          proof = url
+        } else {
+          console.warn('Proof generation failed for', choice)
+        }
+      } catch (err) {
+        console.error('proof generation', err)
+      }
     }
+
+    addItem({ slug, title, variant: choice, image: coverUrl, proof })
+    onAdd?.(choice)
+    onClose()
+    setChoice(null)
   }
 
   return (

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -13,7 +13,7 @@ interface Props {
   coverUrl: string
   products?: { title: string; variantHandle: string }[]
   onAdd?: (variant: string) => void
-  generateProof?: (variant: string) => Promise<string | null>
+  generateProofUrl?: (variant: string) => Promise<string | null>
 }
 
 const DEFAULT_OPTIONS = [
@@ -23,7 +23,7 @@ const DEFAULT_OPTIONS = [
   { label: 'Giant Card', handle: 'gc-large' },
 ]
 
-export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProof }: Props) {
+export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProofUrl }: Props) {
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
@@ -38,7 +38,7 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
 
   const handleAdd = async () => {
     if (choice) {
-      const proof = (await generateProof?.(choice)) || ''
+      const proof = (await generateProofUrl?.(choice)) || ''
       addItem({ slug, title, variant: choice, image: coverUrl, proof })
       onAdd?.(choice)
       onClose()

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -13,6 +13,7 @@ interface Props {
   coverUrl: string
   products?: { title: string; variantHandle: string }[]
   onAdd?: (variant: string) => void
+  generateProof?: (variant: string) => Promise<string | null>
 }
 
 const DEFAULT_OPTIONS = [
@@ -22,7 +23,7 @@ const DEFAULT_OPTIONS = [
   { label: 'Giant Card', handle: 'gc-large' },
 ]
 
-export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd }: Props) {
+export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProof }: Props) {
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
@@ -35,9 +36,10 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
     products?.map(p => ({ label: p.title, handle: canonical[p.variantHandle] ?? p.variantHandle }))
     || DEFAULT_OPTIONS
 
-  const handleAdd = () => {
+  const handleAdd = async () => {
     if (choice) {
-      addItem({ slug, title, variant: choice, image: coverUrl })
+      const proof = (await generateProof?.(choice)) || ''
+      addItem({ slug, title, variant: choice, image: coverUrl, proof })
       onAdd?.(choice)
       onClose()
       setChoice(null)

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -27,14 +27,7 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
-  const canonical: Record<string, string> = {
-    mini: 'gc-mini',
-    classic: 'gc-classic',
-    giant: 'gc-large',
-  }
-  const options =
-    products?.map(p => ({ label: p.title, handle: canonical[p.variantHandle] ?? p.variantHandle }))
-    || DEFAULT_OPTIONS
+  const options = products?.map(p => ({ label: p.title, handle: p.variantHandle })) || DEFAULT_OPTIONS
 
   const handleAdd = async () => {
     if (choice) {

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -11,19 +11,22 @@ interface Props {
   slug: string
   title: string
   coverUrl: string
+  products?: { title: string; variantHandle: string }[]
   onAdd?: (variant: string) => void
 }
 
-const OPTIONS = [
-  { label: 'Digital Card', sku: 'digital' },
-  { label: 'Mini Card', sku: 'mini' },
-  { label: 'Classic Card', sku: 'classic' },
-  { label: 'Giant Card', sku: 'giant' },
+const DEFAULT_OPTIONS = [
+  { label: 'Digital Card', handle: 'digital' },
+  { label: 'Mini Card', handle: 'gc-mini' },
+  { label: 'Classic Card', handle: 'gc-classic' },
+  { label: 'Giant Card', handle: 'gc-large' },
 ]
 
-export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, onAdd }: Props) {
+export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd }: Props) {
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
+
+  const options = products?.map(p => ({ label: p.title, handle: p.variantHandle })) || DEFAULT_OPTIONS
 
   const handleAdd = () => {
     if (choice) {
@@ -54,14 +57,14 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
           <Dialog.Panel className="relative z-10 bg-white rounded shadow-lg w-[min(90vw,420px)] p-6 space-y-6">
             <h2 className="font-domine text-xl text-[--walty-teal]">Choose an option</h2>
             <ul className="space-y-2">
-              {OPTIONS.map((opt) => (
-                <li key={opt.sku}>
+              {options.map((opt) => (
+                <li key={opt.handle}>
                   <button
-                    onClick={() => setChoice(opt.sku)}
-                    className={`w-full flex items-center justify-between border rounded-md p-3 ${choice === opt.sku ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
+                    onClick={() => setChoice(opt.handle)}
+                    className={`w-full flex items-center justify-between border rounded-md p-3 ${choice === opt.handle ? 'border-[--walty-orange] bg-[--walty-cream]' : 'border-gray-300'}`}
                   >
                     <span>{opt.label}</span>
-                    {choice === opt.sku && <Check className="text-[--walty-orange]" size={20} />}
+                    {choice === opt.handle && <Check className="text-[--walty-orange]" size={20} />}
                   </button>
                 </li>
               ))}

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -499,6 +499,19 @@ const fetchProofBlob = async (
   return null
 }
 
+/* helper – return proof as Data URL for given variant */
+const generateProofDataURL = async (variant: string) => {
+  const { pages, pageImages } = collectProofData()
+  const blob = await fetchProofBlob(variant, `${variant}.jpg`, pages, pageImages)
+  if (!blob) return ''
+  return await new Promise<string>((res, rej) => {
+    const reader = new FileReader()
+    reader.onerror = () => rej(new Error('read failed'))
+    reader.onload = () => res(reader.result as string)
+    reader.readAsDataURL(blob)
+  })
+}
+
 /* download proofs for all products */
 const handleProofAll = async () => {
   if (!products.length) return
@@ -725,6 +738,7 @@ const handleProofAll = async () => {
         title={title}
         coverUrl={thumbs[0] || coverImage || ''}
         products={products}
+        generateProof={generateProofDataURL}
       />
     </div>
   )

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -747,7 +747,7 @@ const handleProofAll = async () => {
         onClose={() => setBasketOpen(false)}
         slug={slug}
         title={title}
-        coverUrl={thumbs[0] || coverImage || ''}
+        coverUrl={coverImage || ''}
         products={products}
         generateProofUrl={generateProofURL}
       />

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -504,10 +504,10 @@ const fetchProofBlob = async (
 }
 
 /* helper – generate proof, upload to Sanity and return its CDN URL */
-const generateProofURL = async (variant: string) => {
+const generateProofURL = async (variant: string): Promise<string | null> => {
   const { pages, pageImages } = collectProofData()
   const blob = await fetchProofBlob(variant, `${variant}.jpg`, pages, pageImages)
-  if (!blob) return ''
+  if (!blob) return null
 
   try {
     const form = new FormData()
@@ -515,12 +515,12 @@ const generateProofURL = async (variant: string) => {
     const res = await fetch('/api/upload', { method: 'POST', body: form })
     if (res.ok) {
       const { url } = await res.json()
-      return typeof url === 'string' ? url : ''
+      return typeof url === 'string' && url ? url : null
     }
   } catch (err) {
     console.error('proof upload', err)
   }
-  return ''
+  return null
 }
 
 /* download proofs for all products */

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -72,6 +72,20 @@ function CoachMark({ anchor, onClose }: { anchor: DOMRect | null; onClose: () =>
 }
 
 /* ────────────────────────────────────────────────────────────────── */
+export interface CardEditorProps {
+  initialPages: TemplatePage[] | undefined
+  templateId?: string
+  slug: string
+  title: string
+  coverImage?: string
+  printSpec?: PrintSpec
+  previewSpec?: PreviewSpec
+  products?: TemplateProduct[]
+  proofUrl?: string
+  mode?: Mode
+  onSave?: SaveFn
+}
+
 export default function CardEditor({
   initialPages,
   templateId,
@@ -81,20 +95,10 @@ export default function CardEditor({
   printSpec,
   previewSpec,
   products = [],
+  proofUrl = '',
   mode = 'customer',
   onSave,
-}: {
-  initialPages: TemplatePage[] | undefined
-  templateId?: string
-  slug: string
-  title: string
-  coverImage?: string
-  printSpec?: PrintSpec
-  previewSpec?: PreviewSpec
-  products?: TemplateProduct[]
-  mode?: Mode
-  onSave?: SaveFn
-}) {
+}: CardEditorProps) {
   if (printSpec) {
     setPrintSpec(printSpec)
     setEditorSpec(printSpec)

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -724,6 +724,7 @@ const handleProofAll = async () => {
         slug={slug}
         title={title}
         coverUrl={thumbs[0] || coverImage || ''}
+        products={products}
       />
     </div>
   )

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -21,6 +21,8 @@ export interface TemplateProduct {
   _id: string
   slug: string
   title: string
+  variantHandle: string
+  price?: number
   printSpec?: PrintSpec
   showSafeArea?: boolean
 }
@@ -57,6 +59,8 @@ export async function getTemplatePages(
       _id,
       title,
       "slug": slug.current,
+      variantHandle,
+      price,
       "printSpec": coalesce(printSpec->, printSpec),
       showSafeArea
     },
@@ -83,7 +87,15 @@ export async function getTemplatePages(
     pages?: any[]
     coverImage?: any
     previewSpec?: PreviewSpec
-    products?: { _id: string; title: string; slug: string; printSpec?: PrintSpec }[]
+    products?: {
+      _id: string
+      title: string
+      slug: string
+      variantHandle: string
+      price?: number
+      printSpec?: PrintSpec
+      showSafeArea?: boolean
+    }[]
   }>(query, params)
 
   const pages = Array.isArray(raw?.pages) && raw.pages.length === 4

--- a/commerce/getProdigiPayload.ts
+++ b/commerce/getProdigiPayload.ts
@@ -23,11 +23,17 @@ export async function getProdigiPayload(
   const map = await sanity.fetch<{prodigiSku:string,printAreaId:string,sizingStrategy:string,shippingMethod:string}>(query, {v: variantHandle, f: fulfilHandle})
   if (!map) throw new Error(`SKU mapping not found for ${variantHandle}_${fulfilHandle}`)
 
+  const printArea = map.printAreaId === 'front' ? 'default' : map.printAreaId
+  const shippingMethodFix: Record<string, string> = {
+    uk_mail_standard: 'uk_mail_tracked48',
+  }
+  const shippingMethod = shippingMethodFix[map.shippingMethod] || map.shippingMethod
+
   return {
     sku: map.prodigiSku,
     copies,
     sizing: map.sizingStrategy,
-    shippingMethod: map.shippingMethod,
-    assets: assets.map(a => ({ url: a.url, printArea: map.printAreaId })),
+    shippingMethod,
+    assets: assets.map(a => ({ url: a.url, printArea })),
   }
 }

--- a/lib/useBasket.tsx
+++ b/lib/useBasket.tsx
@@ -30,7 +30,19 @@ export function BasketProvider({ children }: { children: React.ReactNode }) {
     if (typeof window === "undefined") return [];
     try {
       const stored = window.localStorage.getItem("basket");
-      return stored ? JSON.parse(stored) : [];
+      const parsed = stored ? JSON.parse(stored) : [];
+      const map: Record<string, string> = {
+        mini: "gc-mini",
+        classic: "gc-classic",
+        giant: "gc-large",
+      };
+      return Array.isArray(parsed)
+        ? parsed.map((it: BasketItem) => ({
+            ...it,
+            variant: map[it.variant] ?? it.variant,
+            id: `${it.slug}_${map[it.variant] ?? it.variant}`,
+          }))
+        : [];
     } catch {
       return [];
     }

--- a/lib/useBasket.tsx
+++ b/lib/useBasket.tsx
@@ -59,19 +59,13 @@ export function BasketProvider({ children }: { children: React.ReactNode }) {
   }, [items]);
 
   const addItem = (item: { slug: string; title: string; variant: string; image: string; proof: string }) => {
-    const canonical: Record<string, string> = {
-      mini: 'gc-mini',
-      classic: 'gc-classic',
-      giant: 'gc-large',
-    }
-    const variant = canonical[item.variant] ?? item.variant
     setItems((prev) => {
-      const id = `${item.slug}_${variant}`
+      const id = `${item.slug}_${item.variant}`
       const existing = prev.find((it) => it.id === id)
       if (existing) {
         return prev.map((it) => (it.id === id ? { ...it, qty: it.qty + 1 } : it))
       }
-      return [...prev, { id, qty: 1, ...item, variant }]
+      return [...prev, { id, qty: 1, ...item }]
     })
   }
 

--- a/lib/useBasket.tsx
+++ b/lib/useBasket.tsx
@@ -57,15 +57,19 @@ export function BasketProvider({ children }: { children: React.ReactNode }) {
   }, [items]);
 
   const addItem = (item: { slug: string; title: string; variant: string; image: string }) => {
+    const canonical: Record<string, string> = {
+      mini: 'gc-mini',
+      classic: 'gc-classic',
+      giant: 'gc-large',
+    }
+    const variant = canonical[item.variant] ?? item.variant
     setItems((prev) => {
-      const id = `${item.slug}_${item.variant}`
+      const id = `${item.slug}_${variant}`
       const existing = prev.find((it) => it.id === id)
       if (existing) {
-        return prev.map((it) =>
-          it.id === id ? { ...it, qty: it.qty + 1 } : it
-        )
+        return prev.map((it) => (it.id === id ? { ...it, qty: it.qty + 1 } : it))
       }
-      return [...prev, { id, qty: 1, ...item }]
+      return [...prev, { id, qty: 1, ...item, variant }]
     })
   }
 

--- a/lib/useBasket.tsx
+++ b/lib/useBasket.tsx
@@ -8,12 +8,13 @@ export interface BasketItem {
   title: string;
   variant: string;
   image: string;
+  proof: string;
   qty: number;
 }
 
 interface BasketContextValue {
   items: BasketItem[];
-  addItem: (item: { slug: string; title: string; variant: string; image: string }) => void;
+  addItem: (item: { slug: string; title: string; variant: string; image: string; proof: string }) => void;
   removeItem: (id: string) => void;
   updateQty: (id: string, qty: number) => void;
 }
@@ -39,6 +40,7 @@ export function BasketProvider({ children }: { children: React.ReactNode }) {
       return Array.isArray(parsed)
         ? parsed.map((it: BasketItem) => ({
             ...it,
+            proof: it.proof || '',
             variant: map[it.variant] ?? it.variant,
             id: `${it.slug}_${map[it.variant] ?? it.variant}`,
           }))
@@ -56,7 +58,7 @@ export function BasketProvider({ children }: { children: React.ReactNode }) {
     }
   }, [items]);
 
-  const addItem = (item: { slug: string; title: string; variant: string; image: string }) => {
+  const addItem = (item: { slug: string; title: string; variant: string; image: string; proof: string }) => {
     const canonical: Record<string, string> = {
       mini: 'gc-mini',
       classic: 'gc-classic',


### PR DESCRIPTION
## Summary
- include variantHandle in Sanity template data
- pass products list through customise pages and card editor
- let AddToBasketDialog use canonical variant handles
- update checkout size options with new ids

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm run build` *(fails: cannot fetch fonts due to network)*
- `npx tsc --noEmit` *(fails: several type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853eaad3f008323a71b17d0a3b697cd