### PR TITLE
propagate fabric scale

### DIFF
--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -12,8 +12,7 @@ import { useEffect, useRef, useState } from 'react'
 import { fabric }            from 'fabric'
 import { useEditor }         from './EditorStore'
 import { fromSanity }        from '@/app/library/layerAdapters'
-import '@/lib/fabricDefaults'
-import { SEL_COLOR } from '@/lib/fabricDefaults';
+import { SEL_COLOR, setFabricScale } from '@/lib/fabricDefaults'
 import { CropTool } from '@/lib/CropTool'
 import { enableSnapGuides } from '@/lib/useSnapGuides'
 import ContextMenu from './ContextMenu'
@@ -70,6 +69,7 @@ function recompute() {
   PREVIEW_W = currentPreview.previewWidthPx
   PREVIEW_H = currentPreview.previewHeightPx
   SCALE = PREVIEW_W / PAGE_W
+  setFabricScale(SCALE)
   PAD = 4 / SCALE
   // compute safe-zone after scaling so rounding happens in preview pixels
   const safeXPreview = safeInsetXIn * currentSpec.dpi * SCALE

--- a/lib/fabricDefaults.ts
+++ b/lib/fabricDefaults.ts
@@ -1,15 +1,33 @@
 /*  fabricDefaults.ts  */
 import { fabric } from 'fabric';
 
-/* ————— constants ————— */
-export const SCALE        = 420 / 1772;        // or the real SCALE you compute
+/* ————— runtime scale ————— */
+let SCALE = 420 / 1772;       // default before FabricCanvas provides a value
+
 export const SEL_COLOR    = '#2EC4B6';         // brand teal – shared everywhere
 export const HANDLE_SHADOW = 'rgba(0,0,0,0.15)';
-export const HANDLE_BLUR   = 1 / SCALE;
+let HANDLE_BLUR   = 1 / SCALE;
+
+/**
+ * Apply the current SCALE to Fabric's global defaults.
+ */
+function applyScale() {
+  (fabric.Object.prototype as any).cornerSize      = Math.round(3 / SCALE);
+  (fabric.Object.prototype as any).touchCornerSize = Math.round(3 / SCALE);
+  HANDLE_BLUR = 1 / SCALE;
+}
+
+/**
+ * Update scale at runtime and recompute dependent values.
+ */
+export const setFabricScale = (scale: number) => {
+  SCALE = scale;
+  applyScale();
+};
+
+applyScale();
 
 /* ————— global Fabric defaults ————— */
-(fabric.Object.prototype as any).cornerSize        = Math.round(3 / SCALE);
-(fabric.Object.prototype as any).touchCornerSize   = Math.round(3 / SCALE);
 (fabric.Object.prototype as any).borderScaleFactor = 1;
 (fabric.Object.prototype as any).borderColor       = SEL_COLOR;
 (fabric.Object.prototype as any).borderDashArray   = [];


### PR DESCRIPTION
## Summary
- allow `lib/fabricDefaults.ts` to update its scale at runtime
- hook `FabricCanvas` recompute logic to update Fabric defaults

## Testing
- `npm run lint` *(fails: react-hooks/rules-of-hooks etc.)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module '@dnd-kit/core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6854668e9d348323a4fd18c0dfed917e