### PR TITLE
Refactor preview spec location

### DIFF
--- a/app/api/templates/[id]/route.ts
+++ b/app/api/templates/[id]/route.ts
@@ -55,7 +55,7 @@ export async function PATCH(
     }
 
     const specRes = await sanity.fetch<{spec: PrintSpec | null}>(
-      `*[_type=="cardTemplate" && _id==$id][0]{"spec":coalesce(products[0]->printSpec->, products[0]->printSpec)}`,
+      `*[_type=="cardTemplate" && _id==$id][0]{"spec":coalesce(product->variants[0]->printSpec->, product->variants[0]->printSpec)}`,
       { id: params.id }
     )
     const spec = specRes?.spec || {

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -54,8 +54,8 @@ export async function getTemplatePages(
     )
   ] | order(_updatedAt desc)[0]{
     coverImage,
-    previewSpec,
-    "products": products[]->{
+    "previewSpec": product->previewSpec,
+    "products": product->variants[]->{
       _id,
       title,
       "slug": slug.current,

--- a/sanity/schemaTypes/cardTemplate.ts
+++ b/sanity/schemaTypes/cardTemplate.ts
@@ -120,33 +120,6 @@ export default defineType({
       validation: r => r.required(),
     }),
 
-    defineField({
-      name: 'previewSpec',
-      type: 'object',
-      title: 'Preview canvas',
-      group: 'basic',
-      fields: [
-        {
-          name: 'previewWidthPx',
-          type: 'number',
-          title: 'Width (px)',
-          initialValue: 420,
-          validation: r => r.required().positive(),
-        },
-        {
-          name: 'previewHeightPx',
-          type: 'number',
-          title: 'Height (px)',
-          initialValue: 580,
-          validation: r => r.required().positive(),
-        },
-        defineField({
-          name: 'maxMobileWidthPx',
-          type: 'number',
-          title: 'Max mobile width (px)',
-        }),
-      ],
-    }),
 
     /* —— Pages —————————————————————————— */
     defineField({
@@ -198,13 +171,12 @@ export default defineType({
       validation: r => r.required(),
     }),
     defineField({
-      name: 'products',
-      type: 'array',
-      title: 'Available as…',
+      name: 'product',
+      type: 'reference',
+      title: 'Product',
       group: 'store',
-      of: [{type: 'reference', to: [{type: 'cardProduct'}]}],
-      validation: r =>
-        r.min(1).error('Choose at least one product SKU'),
+      to: [{type: 'product'}],
+      validation: r => r.required(),
     }),
     defineField({
       name: 'description',

--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -23,6 +23,33 @@ export default defineType({
       type: 'text',
       title: 'Description',
     }),
+
+    defineField({
+      name: 'previewSpec',
+      type: 'object',
+      title: 'Preview canvas',
+      fields: [
+        {
+          name: 'previewWidthPx',
+          type: 'number',
+          title: 'Width (px)',
+          initialValue: 420,
+          validation: r => r.required().positive(),
+        },
+        {
+          name: 'previewHeightPx',
+          type: 'number',
+          title: 'Height (px)',
+          initialValue: 580,
+          validation: r => r.required().positive(),
+        },
+        defineField({
+          name: 'maxMobileWidthPx',
+          type: 'number',
+          title: 'Max mobile width (px)',
+        }),
+      ],
+    }),
     defineField({
       name: 'variants',
       type: 'array',

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -85,7 +85,7 @@ export const structure: StructureResolver = (S: StructureBuilder) =>
                           S.documentTypeList('cardTemplate')
                             .title('Portrait')
                             .filter(
-                              '_type == "cardTemplate" && previewSpec.previewHeightPx > previewSpec.previewWidthPx'
+                              '_type == "cardTemplate" && product->previewSpec.previewHeightPx > product->previewSpec.previewWidthPx'
                             )
                             .child((id) => cardTemplateNode(S, id)),
                         ),
@@ -95,7 +95,7 @@ export const structure: StructureResolver = (S: StructureBuilder) =>
                           S.documentTypeList('cardTemplate')
                             .title('Landscape')
                             .filter(
-                              '_type == "cardTemplate" && previewSpec.previewWidthPx > previewSpec.previewHeightPx'
+                              '_type == "cardTemplate" && product->previewSpec.previewWidthPx > product->previewSpec.previewHeightPx'
                             )
                             .child((id) => cardTemplateNode(S, id)),
                         ),
@@ -105,7 +105,7 @@ export const structure: StructureResolver = (S: StructureBuilder) =>
                           S.documentTypeList('cardTemplate')
                             .title('Square')
                             .filter(
-                              '_type == "cardTemplate" && previewSpec.previewWidthPx == previewSpec.previewHeightPx'
+                              '_type == "cardTemplate" && product->previewSpec.previewWidthPx == product->previewSpec.previewHeightPx'
                             )
                             .child((id) => cardTemplateNode(S, id)),
                         ),


### PR DESCRIPTION
## Summary
- move previewSpec to product schema
- link card templates to products instead of variants
- adapt template queries to load previewSpec from products
- update orientation filters in desk structure
- adjust API route to use product data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854845660808323a3edcf4083eb86e6