### PR TITLE
Enable safe-zone guides from product metadata

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -14,6 +14,7 @@ import FabricCanvas, {
   setPrintSpec,
   setPreviewSpec,
   setSafeInset,
+  setSafeInsetPx,
   PrintSpec,
   PreviewSpec,
   previewW,
@@ -110,7 +111,15 @@ export default function CardEditor({
     setPreviewSpec(previewSpec)
   }
   useEffect(() => {
-    if (!printSpec || !previewSpec || !products.length) return
+    if (!printSpec || !previewSpec) return
+
+    // 1️⃣  explicit safe insets from the preview spec
+    if (previewSpec.safeInsetXPx || previewSpec.safeInsetYPx) {
+      setSafeInsetPx(previewSpec.safeInsetXPx ?? 0, previewSpec.safeInsetYPx ?? 0)
+      return
+    }
+
+    if (!products.length) return
     const baseW = printSpec.trimWidthIn + printSpec.bleedIn * 2
     const baseH = printSpec.trimHeightIn + printSpec.bleedIn * 2
     const baseRatio = baseW / baseH
@@ -456,7 +465,7 @@ const handlePreview = () => {
 }
 
 /* helper – gather pages and rendered images once */
-const collectProofData = () => {
+const collectProofData = (showGuides = false) => {
   canvasMap.forEach(fc => {
     const tool = (fc as any)?._cropTool as CropTool | undefined
     if (tool?.isActive) tool.commit()
@@ -471,12 +480,12 @@ const collectProofData = () => {
   canvasMap.forEach(fc => {
     if (!fc) { pageImages.push(''); return }
     const guides = fc.getObjects().filter(o => (o as any)._guide)
-    guides.forEach(g => g.set('visible', false))
+    if (!showGuides) guides.forEach(g => g.set('visible', false))
     fc.renderAll()
     pageImages.push(
       fc.toDataURL({ format: 'png', quality: 1, multiplier: EXPORT_MULT() })
     )
-    guides.forEach(g => g.set('visible', true))
+    if (!showGuides) guides.forEach(g => g.set('visible', true))
   })
   return { pages, pageImages }
 }
@@ -505,7 +514,8 @@ const fetchProofBlob = async (
 
 /* helper – generate proof, upload to Sanity and return its CDN URL */
 const generateProofURL = async (variant: string): Promise<string | null> => {
-  const { pages, pageImages } = collectProofData()
+  const showGuides = products.find(p => p.variantHandle === variant)?.showProofSafeArea ?? false
+  const { pages, pageImages } = collectProofData(showGuides)
   const blob = await fetchProofBlob(variant, `${variant}.jpg`, pages, pageImages)
   if (!blob) return null
 
@@ -526,12 +536,11 @@ const generateProofURL = async (variant: string): Promise<string | null> => {
 /* download proofs for all products */
 const handleProofAll = async () => {
   if (!products.length) return
-  const { pages, pageImages } = collectProofData()
-  
   const JSZip = (await import('jszip')).default
 
   const zip = new JSZip()
   for (const p of products) {
+    const { pages, pageImages } = collectProofData(p.showProofSafeArea)
     const name = `${p.slug}.jpg`
     const blob = await fetchProofBlob(p.slug, name, pages, pageImages)
     if (blob) zip.file(name, blob)

--- a/app/components/FabricCanvas.tsx
+++ b/app/components/FabricCanvas.tsx
@@ -45,6 +45,8 @@ export interface PreviewSpec {
   previewWidthPx: number
   previewHeightPx: number
   maxMobileWidthPx?: number
+  safeInsetXPx?: number
+  safeInsetYPx?: number
 }
 
 let currentSpec: PrintSpec = {
@@ -57,6 +59,8 @@ let currentSpec: PrintSpec = {
 let currentPreview: PreviewSpec = {
   previewWidthPx: 420,
   previewHeightPx: 580,
+  safeInsetXPx: 0,
+  safeInsetYPx: 0,
 }
 
 let safeInsetXIn = 0
@@ -87,6 +91,13 @@ export const setPrintSpec = (spec: PrintSpec) => {
 export const setSafeInset = (xIn: number, yIn: number) => {
   safeInsetXIn = xIn
   safeInsetYIn = yIn
+  recompute()
+}
+
+export const setSafeInsetPx = (xPx: number, yPx: number) => {
+  const scale = SCALE || (PREVIEW_W / PAGE_W)
+  safeInsetXIn = xPx / (currentSpec.dpi * scale)
+  safeInsetYIn = yPx / (currentSpec.dpi * scale)
   recompute()
 }
 

--- a/app/library/getTemplatePages.ts
+++ b/app/library/getTemplatePages.ts
@@ -25,6 +25,7 @@ export interface TemplateProduct {
   price?: number
   printSpec?: PrintSpec
   showSafeArea?: boolean
+  showProofSafeArea?: boolean
 }
 
 export interface TemplateData {
@@ -62,7 +63,8 @@ export async function getTemplatePages(
       variantHandle,
       price,
       "printSpec": coalesce(printSpec->, printSpec),
-      "showSafeArea": ^.showSafeArea
+      "showSafeArea": ^.showSafeArea,
+      "showProofSafeArea": ^.showProofSafeArea
     },
     pages[]{
       layers[]{
@@ -95,6 +97,7 @@ export async function getTemplatePages(
       price?: number
       printSpec?: PrintSpec
       showSafeArea?: boolean
+      showProofSafeArea?: boolean
     }[]
   }>(query, params)
 

--- a/sanity/schemaTypes/product.ts
+++ b/sanity/schemaTypes/product.ts
@@ -81,6 +81,15 @@ export default defineType({
     validation: r => r.required(),
   }),
   defineField({
+    name: 'showProofSafeArea',
+    type: 'boolean',
+    title: 'Show safe-area in proofs',
+    initialValue: false,
+    description: 'Include the green safe guide in generated proofs',
+    options: { layout: 'switch' },
+    validation: r => r.required(),
+  }),
+  defineField({
     name: 'variants',
     type: 'array',
     title: 'Variants',


### PR DESCRIPTION
## Summary
- support `safeInsetXPx` and `safeInsetYPx` in the `PreviewSpec`
- compute safe guides from these fields when available
- expose helper `setSafeInsetPx`
- add toggle to show safe-area in final proofs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685536fa7c7c832392b27ef1e81a1e98