### PR TITLE
Implement bulk proof generation

### DIFF
--- a/app/checkout/CheckoutClient.tsx
+++ b/app/checkout/CheckoutClient.tsx
@@ -10,6 +10,7 @@ export interface CartItem {
   id: string;
   coverUrl: string;
   proofUrl: string;
+  proofs: Record<string, string>;
   title: string;
   sku: string;
   variant: string;
@@ -66,7 +67,14 @@ export default function CheckoutClient({
     if (!size) return;
     setCartItems((prev) =>
       prev.map((it) =>
-        it.id === id ? { ...it, variant, price: size.price } : it,
+        it.id === id
+          ? {
+              ...it,
+              variant,
+              price: size.price,
+              proofUrl: it.proofs[variant] || it.proofUrl,
+            }
+          : it,
       ),
     );
   };

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -9,7 +9,8 @@ export default function CheckoutPage() {
   const cartItems = items.map((it) => ({
     id: it.id,
     coverUrl: it.image,
-    proofUrl: it.proof,
+    proofUrl: it.proofs[it.variant] ?? '',
+    proofs: it.proofs,
     title: it.title,
     sku: it.slug,
     variant: it.variant,

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -13,7 +13,7 @@ interface Props {
   coverUrl: string
   products?: { title: string; variantHandle: string }[]
   onAdd?: (variant: string) => void
-  generateProofUrl?: (variant: string) => Promise<string | null>
+  generateProofUrls?: (variants: string[]) => Promise<Record<string, string>>
 }
 
 const DEFAULT_OPTIONS = [
@@ -23,7 +23,7 @@ const DEFAULT_OPTIONS = [
   { label: 'Giant Card', handle: 'gc-large' },
 ]
 
-export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProofUrl }: Props) {
+export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl, products, onAdd, generateProofUrls }: Props) {
   const [choice, setChoice] = useState<string | null>(null)
   const { addItem } = useBasket()
 
@@ -37,9 +37,10 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
     if (!choice) return
 
     let proof = ''
-    if (generateProofUrl) {
+    if (generateProofUrls) {
       try {
-        const url = await generateProofUrl(choice)
+        const urls = await generateProofUrls([choice])
+        const url = urls[choice]
         if (typeof url === 'string' && url) {
           proof = url
         } else {

--- a/app/components/AddToBasketDialog.tsx
+++ b/app/components/AddToBasketDialog.tsx
@@ -37,9 +37,11 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
     if (!choice) return
 
     let proof = ''
+    let proofs: Record<string, string> = {}
     if (generateProofUrls) {
       try {
-        const urls = await generateProofUrls([choice])
+        const urls = await generateProofUrls(options.map(o => o.handle))
+        proofs = urls
         const url = urls[choice]
         if (typeof url === 'string' && url) {
           proof = url
@@ -54,7 +56,7 @@ export default function AddToBasketDialog({ open, onClose, slug, title, coverUrl
     }
 
     if (!proof) return
-    addItem({ slug, title, variant: choice, image: coverUrl, proof })
+    addItem({ slug, title, variant: choice, image: coverUrl, proofs })
     onAdd?.(choice)
     onClose()
     setChoice(null)

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -501,7 +501,7 @@ const fetchProofBlob = async (
     const res = await fetch('/api/proof', {
       method : 'POST',
       headers: { 'content-type': 'application/json' },
-      body   : JSON.stringify({ pages, pageImages, sku, id: templateId, filename }),
+      body   : JSON.stringify({ pages, pageImages, sku, id: templateId ?? slug, filename }),
     })
     if (res.ok) {
       return await res.blob()

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -513,15 +513,17 @@ const fetchProofBlob = async (
 }
 
 /* helper – generate proof, upload to Sanity and return its CDN URL */
-const generateProofURL = async (variant: string): Promise<string | null> => {
-  const showGuides = products.find(p => p.variantHandle === variant)?.showProofSafeArea ?? false
+const generateProofURL = async (variantHandle: string): Promise<string | null> => {
+  const product = products.find(p => p.variantHandle === variantHandle)
+  const sku = product?.slug ?? variantHandle
+  const showGuides = product?.showProofSafeArea ?? false
   const { pages, pageImages } = collectProofData(showGuides)
-  const blob = await fetchProofBlob(variant, `${variant}.jpg`, pages, pageImages)
+  const blob = await fetchProofBlob(sku, `${variantHandle}.jpg`, pages, pageImages)
   if (!blob) return null
 
   try {
     const form = new FormData()
-    form.append('file', new File([blob], `${variant}.jpg`, { type: blob.type }))
+    form.append('file', new File([blob], `${variantHandle}.jpg`, { type: blob.type }))
     const res = await fetch('/api/upload', { method: 'POST', body: form })
     if (res.ok) {
       const { url } = await res.json()

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -533,6 +533,20 @@ const generateProofURL = async (variant: string): Promise<string | null> => {
   return null
 }
 
+const generateProofURLs = async (
+  handles: string[],
+): Promise<Record<string, string>> => {
+  const entries = await Promise.all(
+    handles.map(async h => [h, await generateProofURL(h)] as const),
+  )
+  const urls: Record<string, string> = {}
+  for (const [h, url] of entries) {
+    if (url) urls[h] = url
+  }
+  if (Object.keys(urls).length === 0) throw new Error('proof generation failed')
+  return urls
+}
+
 /* download proofs for all products */
 const handleProofAll = async () => {
   if (!products.length) return
@@ -758,7 +772,7 @@ const handleProofAll = async () => {
         title={title}
         coverUrl={coverImage || ''}
         products={products}
-        generateProofUrl={generateProofURL}
+        generateProofUrls={generateProofURLs}
       />
     </div>
   )

--- a/lib/useBasket.tsx
+++ b/lib/useBasket.tsx
@@ -8,13 +8,13 @@ export interface BasketItem {
   title: string;
   variant: string;
   image: string;
-  proof: string;
+  proofs: Record<string, string>;
   qty: number;
 }
 
 interface BasketContextValue {
   items: BasketItem[];
-  addItem: (item: { slug: string; title: string; variant: string; image: string; proof: string }) => void;
+  addItem: (item: { slug: string; title: string; variant: string; image: string; proofs: Record<string, string> }) => void;
   removeItem: (id: string) => void;
   updateQty: (id: string, qty: number) => void;
 }
@@ -38,9 +38,9 @@ export function BasketProvider({ children }: { children: React.ReactNode }) {
         giant: "gc-large",
       };
       return Array.isArray(parsed)
-        ? parsed.map((it: BasketItem) => ({
+        ? parsed.map((it: any) => ({
             ...it,
-            proof: it.proof || '',
+            proofs: it.proofs || (it.proof ? { [it.variant]: it.proof } : {}),
             variant: map[it.variant] ?? it.variant,
             id: `${it.slug}_${map[it.variant] ?? it.variant}`,
           }))
@@ -58,7 +58,15 @@ export function BasketProvider({ children }: { children: React.ReactNode }) {
     }
   }, [items]);
 
-  const addItem = (item: { slug: string; title: string; variant: string; image: string; proof: string }) => {
+  const addItem = (
+    item: {
+      slug: string;
+      title: string;
+      variant: string;
+      image: string;
+      proofs: Record<string, string>;
+    },
+  ) => {
     setItems((prev) => {
       const id = `${item.slug}_${item.variant}`
       const existing = prev.find((it) => it.id === id)


### PR DESCRIPTION
## Summary
- add `generateProofURLs` for concurrent proof creation
- update AddToBasketDialog to use new API
- wire CardEditor to pass `generateProofURLs`

## Testing
- `npm run lint` *(fails: react-hooks rules)*

------
https://chatgpt.com/codex/tasks/task_e_6857e7f57ba4832384186a54aff1e3d3